### PR TITLE
Fix for Radeon RX max memory clock issue

### DIFF
--- a/linux514-tkg/AMD_fix_max_memory_clock.mypatch
+++ b/linux514-tkg/AMD_fix_max_memory_clock.mypatch
@@ -1,0 +1,63 @@
+This patch reverts the commit that caused some RDNA and RDNA 2 graphics cards (Radeon RX 5- and 6- series) to
+have their memory clock stuck on maximum regardless of the load on the card, causing the power usage while idling
+to spike.
+
+If you have one of these graphics cards and you noticed that the card is running hotter than usual when idling
+(you can check it by running `sensors` or `sudo cat /sys/kernel/debug/dri/0/amdgpu_pm_info`), try to rebuild with
+this patch and see if it helps.
+
+For more information on the issue, see:
+https://gitlab.freedesktop.org/drm/amd/-/issues/1709
+
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+index 3883f918b..83f5d9aaf 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+@@ -1069,7 +1069,7 @@ static const struct dc_debug_options debug_defaults_drv = {
+ 		.timing_trace = false,
+ 		.clock_trace = true,
+ 		.disable_pplib_clock_request = true,
+-		.pipe_split_policy = MPC_SPLIT_AVOID_MULT_DISP,
++		.pipe_split_policy = MPC_SPLIT_DYNAMIC,
+ 		.force_single_disp_pipe_split = false,
+ 		.disable_dcc = DCC_ENABLE,
+ 		.vsr_support = true,
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c b/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c
+index 79a66e0c4..98852b586 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c
+@@ -840,7 +840,7 @@ static const struct dc_debug_options debug_defaults_drv = {
+ 	.timing_trace = false,
+ 	.clock_trace = true,
+ 	.disable_pplib_clock_request = true,
+-	.pipe_split_policy = MPC_SPLIT_AVOID_MULT_DISP,
++	.pipe_split_policy = MPC_SPLIT_DYNAMIC,
+ 	.force_single_disp_pipe_split = false,
+ 	.disable_dcc = DCC_ENABLE,
+ 	.vsr_support = true,
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c b/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c
+index fcf96cf08..16e705939 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c
+@@ -211,7 +211,7 @@ static const struct dc_debug_options debug_defaults_drv = {
+ 		.timing_trace = false,
+ 		.clock_trace = true,
+ 		.disable_pplib_clock_request = true,
+-		.pipe_split_policy = MPC_SPLIT_AVOID_MULT_DISP,
++		.pipe_split_policy = MPC_SPLIT_DYNAMIC,
+ 		.force_single_disp_pipe_split = false,
+ 		.disable_dcc = DCC_ENABLE,
+ 		.vsr_support = true,
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c b/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c
+index 4a9b64023..87cec14b7 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c
+@@ -193,7 +193,7 @@ static const struct dc_debug_options debug_defaults_drv = {
+ 		.timing_trace = false,
+ 		.clock_trace = true,
+ 		.disable_pplib_clock_request = true,
+-		.pipe_split_policy = MPC_SPLIT_AVOID_MULT_DISP,
++		.pipe_split_policy = MPC_SPLIT_DYNAMIC,
+ 		.force_single_disp_pipe_split = false,
+ 		.disable_dcc = DCC_ENABLE,
+ 		.vsr_support = true,

--- a/linux514-tkg/README.md
+++ b/linux514-tkg/README.md
@@ -2,3 +2,4 @@
 
 - OpenRGB.mypatch - Patch to add OpenRGB compatibility for certain i2c controllers - https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/OpenRGB.patch
 - AMD_CPPC.mypatch - Adds AMD CPPC frequency management driver - http://lkml.iu.edu/hypermail/linux/kernel/2109.1/00542.html
+- AMD_fix_max_memory_clock.mypatch - Fixes an issue in AMD GPU driver locking memory clocks at maximum speed for Radeon RX cards - https://gitlab.freedesktop.org/drm/amd/-/issues/1709

--- a/linux515-tkg/AMD_fix_max_memory_clock.mypatch
+++ b/linux515-tkg/AMD_fix_max_memory_clock.mypatch
@@ -1,0 +1,63 @@
+This patch reverts the commit that caused some RDNA and RDNA 2 graphics cards (Radeon RX 5- and 6- series) to
+have their memory clock stuck on maximum regardless of the load on the card, causing the power usage while idling
+to spike.
+
+If you have one of these graphics cards and you noticed that the card is running hotter than usual when idling
+(you can check it by running `sensors` or `sudo cat /sys/kernel/debug/dri/0/amdgpu_pm_info`), try to rebuild with
+this patch and see if it helps.
+
+For more information on the issue, see:
+https://gitlab.freedesktop.org/drm/amd/-/issues/1709
+
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+index 3883f918b..83f5d9aaf 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn20/dcn20_resource.c
+@@ -1069,7 +1069,7 @@ static const struct dc_debug_options debug_defaults_drv = {
+ 		.timing_trace = false,
+ 		.clock_trace = true,
+ 		.disable_pplib_clock_request = true,
+-		.pipe_split_policy = MPC_SPLIT_AVOID_MULT_DISP,
++		.pipe_split_policy = MPC_SPLIT_DYNAMIC,
+ 		.force_single_disp_pipe_split = false,
+ 		.disable_dcc = DCC_ENABLE,
+ 		.vsr_support = true,
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c b/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c
+index 79a66e0c4..98852b586 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn30/dcn30_resource.c
+@@ -840,7 +840,7 @@ static const struct dc_debug_options debug_defaults_drv = {
+ 	.timing_trace = false,
+ 	.clock_trace = true,
+ 	.disable_pplib_clock_request = true,
+-	.pipe_split_policy = MPC_SPLIT_AVOID_MULT_DISP,
++	.pipe_split_policy = MPC_SPLIT_DYNAMIC,
+ 	.force_single_disp_pipe_split = false,
+ 	.disable_dcc = DCC_ENABLE,
+ 	.vsr_support = true,
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c b/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c
+index fcf96cf08..16e705939 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn302/dcn302_resource.c
+@@ -211,7 +211,7 @@ static const struct dc_debug_options debug_defaults_drv = {
+ 		.timing_trace = false,
+ 		.clock_trace = true,
+ 		.disable_pplib_clock_request = true,
+-		.pipe_split_policy = MPC_SPLIT_AVOID_MULT_DISP,
++		.pipe_split_policy = MPC_SPLIT_DYNAMIC,
+ 		.force_single_disp_pipe_split = false,
+ 		.disable_dcc = DCC_ENABLE,
+ 		.vsr_support = true,
+diff --git a/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c b/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c
+index 4a9b64023..87cec14b7 100644
+--- a/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c
++++ b/drivers/gpu/drm/amd/display/dc/dcn303/dcn303_resource.c
+@@ -193,7 +193,7 @@ static const struct dc_debug_options debug_defaults_drv = {
+ 		.timing_trace = false,
+ 		.clock_trace = true,
+ 		.disable_pplib_clock_request = true,
+-		.pipe_split_policy = MPC_SPLIT_AVOID_MULT_DISP,
++		.pipe_split_policy = MPC_SPLIT_DYNAMIC,
+ 		.force_single_disp_pipe_split = false,
+ 		.disable_dcc = DCC_ENABLE,
+ 		.vsr_support = true,

--- a/linux515-tkg/README.md
+++ b/linux515-tkg/README.md
@@ -2,3 +2,4 @@
 
 - OpenRGB.mypatch - Patch to add OpenRGB compatibility for certain i2c controllers - https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/OpenRGB.patch
 - AMD_CPPC.mypatch - Adds AMD CPPC frequency management driver - http://lkml.iu.edu/hypermail/linux/kernel/2109.1/00542.html
+- AMD_fix_max_memory_clock.mypatch - Fixes an issue in AMD GPU driver locking memory clocks at maximum speed for Radeon RX cards - https://gitlab.freedesktop.org/drm/amd/-/issues/1709


### PR DESCRIPTION
Added patch that fixes issue in kernel 5.14 and 5.15 where certain Radeon RX cards lock their memory clocks at maximum frequency, increasing power usage and temperatures when idling. With this patch, the clocks can be reduced once again, lowering both power usage and idle temps.

Issue reported and tracked at FreeDesktop GitLab:
https://gitlab.freedesktop.org/drm/amd/-/issues/1709

Kernels 5.13 and earlier don't experience the issue as the reverted change was only introduced in 5.14-rc1.
I haven't checked whether the issue happens on kernel 5.16 (zfs-dkms fails to build the module for that version, so I can't boot my system from 5.16 yet), but I'll open another PR for that as soon as I can test it.