### PR TITLE
linux516: Remove Auxilliary BUS init

### DIFF
--- a/linux516-tkg/OpenRGB.mypatch
+++ b/linux516-tkg/OpenRGB.mypatch
@@ -701,15 +701,3 @@ index 30ded6422e7b..e25ce84c26af 100644
  
  	/* If the SMBus is still busy, we give up */
  	if (timeout == MAX_TIMEOUT) {
-@@ -981,6 +981,11 @@ static int piix4_probe(struct pci_dev *dev, const struct pci_device_id *id)
- 		retval = piix4_setup_sb800(dev, id, 1);
- 	}
- 
-+	if (dev->vendor == PCI_VENDOR_ID_AMD &&
-+	    dev->device == PCI_DEVICE_ID_AMD_KERNCZ_SMBUS) {
-+		retval = piix4_setup_sb800(dev, id, 1);
-+	}
-+
- 	if (retval > 0) {
- 		/* Try to add the aux adapter if it exists,
- 		 * piix4_add_adapter will clean up if this fails */


### PR DESCRIPTION
an upstream commit already addd it in the previous initialization call

Was casing SMBus region 0xb20 already in use!