### PR TITLE
Fix: drm/i915: prevent direct writeback from the shrinker

### DIFF
--- a/linux54-tkg/SRU-F-UBUNTU-SAUCE-drm-i915-prevent-direct-writeback-from-the-shrinker.mypatch
+++ b/linux54-tkg/SRU-F-UBUNTU-SAUCE-drm-i915-prevent-direct-writeback-from-the-shrinker.mypatch
@@ -1,0 +1,14 @@
+diff --git a/drivers/gpu/drm/i915/gem/i915_gem_shrinker.c b/drivers/gpu/drm/i915/gem/i915_gem_shrinker.c
+index edd21d14e64f..793bd586b80b 100644
+--- a/drivers/gpu/drm/i915/gem/i915_gem_shrinker.c
++++ b/drivers/gpu/drm/i915/gem/i915_gem_shrinker.c
+@@ -357,8 +357,7 @@ i915_gem_shrinker_scan(struct shrinker *shrinker, struct shrink_control *sc)
+ 				sc->nr_to_scan,
+ 				&sc->nr_scanned,
+ 				I915_SHRINK_BOUND |
+-				I915_SHRINK_UNBOUND |
+-				I915_SHRINK_WRITEBACK);
++				I915_SHRINK_UNBOUND);
+ 	if (sc->nr_scanned < sc->nr_to_scan && current_is_kswapd()) {
+ 		intel_wakeref_t wakeref;
+ 


### PR DESCRIPTION
The 5.4 LTS kernel series has a bug with the i915 shrinker which causes users with an integrated Intel graphics chipset to experience high amounts of swap storm trashing and causing the system's interactivity to degrade (kswapd shown as with 300+ MBs of I/O). This patch rectifies the problem.