### PR TITLE
Update Roblox Mouse Fix

### DIFF
--- a/wine-tkg-git/roblox_mouse_fix.mypatch
+++ b/wine-tkg-git/roblox_mouse_fix.mypatch
@@ -6,7 +6,7 @@ index 06c5f7a4981..a2e7e66f977 100644
      Window clip_window;
      HWND msg_hwnd = 0;
      POINT pos;
-+    RECT virtual_rect = get_virtual_screen_rect();
++    RECT virtual_rect = NtUserGetVirtualScreenRect();
 +    if (!EqualRect(clip, &virtual_rect)) reset_clipping_window();
  
      if (GetWindowThreadProcessId( GetDesktopWindow(), NULL ) == GetCurrentThreadId())


### PR DESCRIPTION
A commit upstream (523a6eba0250e734a30b9310ab694e2a2af6d6ca) removed the helper function get_virtual_screen_rect, this replaces it with NtUserGetVirtualScreenRect, which should have the exact same behaviour.