### PR TITLE
wine-tkg-git: Add RtlCreateTimer_fix

### DIFF
--- a/wine-tkg-git/README.md
+++ b/wine-tkg-git/README.md
@@ -37,6 +37,7 @@
 - unprivileged_ICMP.mypatch - Notably fixes missing ping in BF4 (which could lead to kicks on some servers) - https://source.winehq.org/patches/data/207990
 - EA_desktop_fix.mypatch - Allows EA desktop to run - Patch by Esdras Tarsis - https://bugs.winehq.org/show_bug.cgi?id=49887
 - ffxiv_mac.mypatch : Add support for using Final Fantasy XIV with Mac authentication (without HideWineExports)
+- RtlCreateTimer_fix.mypatch: Fix race condition in RtlCreateTimer - affect Guild Wars 2 with Arcdps (no other cases known yet). Since aug.28.2021 there is a temporary workaround on the Arcdps side (just some extra delays have been added, but this may not work for specific hardware) until https://bugs.winehq.org/show_bug.cgi?id=51683 is resolved.
 
 ## Misc
 - 0001-rockstarlauncher_install_fix.mypatch : Fix for rockstar launcher installer crashing - https://github.com/ValveSoftware/wine/commit/e485252dfad51a7e463643d56fe138129597e4b6 - Doesn't apply to proton-tkg or wine builds using `_protonify="true"` (already included)

--- a/wine-tkg-git/RtlCreateTimer_fix.mypatch
+++ b/wine-tkg-git/RtlCreateTimer_fix.mypatch
@@ -1,0 +1,41 @@
+From 7bc7829db283134946d1c7ae0468ddc1bbf993a0 Mon Sep 17 00:00:00 2001
+From: deltaconnected <deltaconnected@gmail.com>
+Date: Thu, 26 Aug 2021 03:06:23 +0200
+Subject: [PATCH] ntdll: Use a critical section for setting the newly created timer in RtlCreateTimer
+
+In RtlCreateTimer, NewTimer is being set after RtlLeaveCriticalSection, which
+seems to allow callbacks created with DueTime == 0 to execute and finish and
+delete an invalid timer before the scheduling thread is switched back.
+
+Fixes crashes inside DeleteTimerQueueEx and DeleteTimerQueueTimer for 
+Guild Wars 2 with Arcdps (https://www.deltaconnected.com/arcdps/)
+
+Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=51683
+---
+ dlls/ntdll/threadpool.c | 7 ++++---
+ 1 file changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/dlls/ntdll/threadpool.c b/dlls/ntdll/threadpool.c
+index ca323919d05..20096573c2b 100644
+--- a/dlls/ntdll/threadpool.c
++++ b/dlls/ntdll/threadpool.c
+@@ -936,12 +936,13 @@ NTSTATUS WINAPI RtlCreateTimer(PHANDLE NewTimer, HANDLE TimerQueue,
+     if (q->quit)
+         status = STATUS_INVALID_HANDLE;
+     else
++    {
++        *NewTimer = t;
+         queue_add_timer(t, queue_current_time() + DueTime, TRUE);
++    }
+     RtlLeaveCriticalSection(&q->cs);
+ 
+-    if (status == STATUS_SUCCESS)
+-        *NewTimer = t;
+-    else
++    if (status != STATUS_SUCCESS)
+         RtlFreeHeap(GetProcessHeap(), 0, t);
+ 
+     return status;
+-- 
+2.33.0
+


### PR DESCRIPTION
Mainly affects Guild Wars 2 with Arcdps (no other cases known yet)

Patch fixes probable race condition in Timer Queues, but optional since deltaconnected made his own workaround on the application side by adding extra delays in the timers. But this may not work for some processors, so he expects such cases to be reported and simply increases delays. But as far as I understand, increasing additional delays directly affects performance, so doing this is infinitely undesirable. He said he would probably add a Wine version check and remove delays after resolving https://bugs.winehq.org/show_bug.cgi?id=51683

I've been using this patch since September 2021 in my builds of Wine for everyday use and haven't noticed any issues caused by this patch so far.