### PR TITLE
linux60-tkg: Add patch to fix clang 16 boot failure

### DIFF
--- a/linux60-tkg/README.md
+++ b/linux60-tkg/README.md
@@ -1,3 +1,4 @@
 # linux60-tkg patches
 
 - OpenRGB.mypatch - Patch to add OpenRGB compatibility for certain i2c controllers - https://gitlab.com/CalcProgrammer1/OpenRGB/-/blob/master/OpenRGB.patch
+- clang16.mypatch - Patch to fix booting when using Clang 16 due to disabling CONFIG_EFI_STUB - https://lore.kernel.org/all/20220929152010.835906-1-nathan@kernel.org/

--- a/linux60-tkg/clang16.mypatch
+++ b/linux60-tkg/clang16.mypatch
@@ -1,0 +1,89 @@
+From mboxrd@z Thu Jan  1 00:00:00 1970
+Received: from smtp.kernel.org (aws-us-west-2-korg-mail-1.web.codeaurora.org [10.30.226.201])
+	(using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+	(No client certificate requested)
+	by smtp.subspace.kernel.org (Postfix) with ESMTPS id 916DD2579;
+	Thu, 29 Sep 2022 15:20:28 +0000 (UTC)
+Received: by smtp.kernel.org (Postfix) with ESMTPSA id 876D1C433C1;
+	Thu, 29 Sep 2022 15:20:27 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=kernel.org;
+	s=k20201202; t=1664464828;
+	bh=bZtdd37VqJjCVyqVFWFxsZ1BmVYfv83mHcIlp+XAedo=;
+	h=From:To:Cc:Subject:Date:From;
+	b=mv/lusf06cppsXLB1un/psyiQzzVLUBTz6IO19L2CrVFkHsesGteiNFIRIOlWQ2tX
+	 E1osPvpkt3Hr6PGTXzK8DdQMbuqLR8gcMUBuxBVYPdeaKHZlCFl0azV+M+ciFeaRjg
+	 Ef4Ere4bkba5NC/M38UmWVBhT7m3GEreGfbHfdDblfh0a2Tqhy0yt41pM69LIPHnJB
+	 fmG6x6pfYVZbqdFiPGGKdTsDE5bf8Kyl2GfgukRoso4JEzmWpAzs3NxLUab8HuVoav
+	 5svSoL/hRnxUliuVRqDkBB1gLBlhZkkeRPnd2p8LTMUZWR9c5jsWBOC3o+/ClwUkEq
+	 o84pVud99QujA==
+From: Nathan Chancellor <nathan@kernel.org>
+To: Ard Biesheuvel <ardb@kernel.org>,
+	Thomas Gleixner <tglx@linutronix.de>,
+	Ingo Molnar <mingo@redhat.com>,
+	Borislav Petkov <bp@alien8.de>,
+	Dave Hansen <dave.hansen@linux.intel.com>,
+	x86@kernel.org
+Cc: "H. Peter Anvin" <hpa@zytor.com>,
+	Nick Desaulniers <ndesaulniers@google.com>,
+	Tom Rix <trix@redhat.com>,
+	linux-kernel@vger.kernel.org,
+	llvm@lists.linux.dev,
+	patches@lists.linux.dev,
+	Nathan Chancellor <nathan@kernel.org>,
+	stable@vger.kernel.org
+Subject: [PATCH] x86/Kconfig: Drop check for '-mabi=ms' for CONFIG_EFI_STUB
+Date: Thu, 29 Sep 2022 08:20:10 -0700
+Message-Id: <20220929152010.835906-1-nathan@kernel.org>
+X-Mailer: git-send-email 2.37.3
+Precedence: bulk
+X-Mailing-List: patches@lists.linux.dev
+List-Id: <patches.lists.linux.dev>
+List-Subscribe: <mailto:patches+subscribe@lists.linux.dev>
+List-Unsubscribe: <mailto:patches+unsubscribe@lists.linux.dev>
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+
+A recent change in LLVM made CONFIG_EFI_STUB unselectable because it no
+longer pretends to support '-mabi=ms', breaking the dependency in
+Kconfig. Lack of CONFIG_EFI_STUB can prevent kernels from booting via
+EFI in certain circumstances.
+
+This check was added by commit 8f24f8c2fc82 ("efi/libstub: Annotate
+firmware routines as __efiapi") to ensure that '__attribute__((ms_abi))'
+was available, as '-mabi=ms' is not actually used in any cflags.
+According to the GCC documentation, this attribute has been supported
+since GCC 4.4.7. The kernel currently requires GCC 5.1 so this check is
+not necessary; even when that change landed in 5.6, the kernel required
+GCC 4.9 so it was unnecessary then as well.  Clang supports
+'__attribute__((ms_abi))' for all versions that are supported for
+building the kernel so no additional check is needed. Remove the
+'depends on' line altogether to allow CONFIG_EFI_STUB to be selected
+when CONFIG_EFI is enabled, regardless of compiler.
+
+Cc: stable@vger.kernel.org
+Fixes: 8f24f8c2fc82 ("efi/libstub: Annotate firmware routines as __efiapi")
+Link: https://github.com/ClangBuiltLinux/linux/issues/1725
+Link: https://gcc.gnu.org/onlinedocs/gcc-4.4.7/gcc/Function-Attributes.html
+Link: https://github.com/llvm/llvm-project/commit/d1ad006a8f64bdc17f618deffa9e7c91d82c444d
+Signed-off-by: Nathan Chancellor <nathan@kernel.org>
+---
+ arch/x86/Kconfig | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/arch/x86/Kconfig b/arch/x86/Kconfig
+index f9920f1341c8..81012154d9ed 100644
+--- a/arch/x86/Kconfig
++++ b/arch/x86/Kconfig
+@@ -1956,7 +1956,6 @@ config EFI
+ config EFI_STUB
+	bool "EFI stub support"
+	depends on EFI
+-	depends on $(cc-option,-mabi=ms) || X86_32
+	select RELOCATABLE
+	help
+	  This kernel feature allows a bzImage to be loaded directly
+
+base-commit: f76349cf41451c5c42a99f18a9163377e4b364ff
+--
+2.37.3
+


### PR DESCRIPTION
while it's pending an upstream merge, add it here for the few people that build with clang built from main

more info: https://github.com/ClangBuiltLinux/linux/issues/1725