### PR TITLE
Rebase patchset for WndProc execution after WH_CALLWNDPROC. Rebase se…

### DIFF
--- a/wine-tkg-git/README.md
+++ b/wine-tkg-git/README.md
@@ -67,5 +67,5 @@
 - 0001-actctx-Use-build_assembly_dir-to-assign-a-directory.mypatch : Allow some applications to properly find some assemblies.
 - 0001-Allow-revocation-check-to-use-the-net.mypatch : Some application that use CERT_VERIFY_CACHE_ONLY_BASED_REVOCATION in bitwise OR with other flags need a full net revocation check. Rustup is affected
 - 0001-Revert-server-Handle-the-entire-IOCTL_AFD_POLL-ioctl.mypatch : Revert the commit that moved IOCTL_AFD_POLL serverside. Rustup (and possible other application that use this routine) need this revert to properly park/unpark the thread.
-- 0001-Execute-hooks-callbacks-even-when-init_window_call_p.mypatch : Execute WH_CALLWNDPROC and WH_CALLWNDPROCRET even if the widget doesn't have  a WinProc associated
+- win32-Initialize-params-for-WndProc-after-WH_CALLWNDPROC.mypatch : Initalize parameters for WndProc procedure after WH_CALLWNDPROC hook is called. (Required )
 - 0001-Force-full-erase-when-WM_PAINT-in-LVS_EX_DOUBLEBUFFE.mypatch : Force a background erase on LVS_EX_DOUBLEBUFFERED listviews. Fix black background for listviews on some apps.

--- a/wine-tkg-git/server-Enable-link-time-optimization.mypatch
+++ b/wine-tkg-git/server-Enable-link-time-optimization.mypatch
@@ -14,9 +14,9 @@ index 739d0517339..2885cff4d10 100644
 @@ -49,6 +49,7 @@ MANPAGES = \
  	wineserver.fr.UTF-8.man.in \
  	wineserver.man.in
- 
--EXTRALIBS = $(LDEXECFLAGS) $(RT_LIBS) $(INOTIFY_LIBS) $(PROCSTAT_LIBS)
-+EXTRALIBS = $(LDEXECFLAGS) $(RT_LIBS) $(INOTIFY_LIBS) $(PROCSTAT_LIBS) -flto=auto -flto-partition=one -fdevirtualize-at-ltrans $(CFLAGS)
+
+-UNIX_LIBS = $(LDEXECFLAGS) $(RT_LIBS) $(INOTIFY_LIBS) $(PROCSTAT_LIBS)
++UNIX_LIBS = $(LDEXECFLAGS) $(RT_LIBS) $(INOTIFY_LIBS) $(PROCSTAT_LIBS) -flto=auto -flto-partition=one -fdevirtualize-at-ltrans $(CFLAGS)
 +EXTRADEFS = -flto=auto -flto-partition=one -fdevirtualize-at-ltrans
  
  unicode_EXTRADEFS = -DNLSDIR="\"${nlsdir}\"" -DBIN_TO_NLSDIR=\"`${MAKEDEP} -R ${bindir} ${nlsdir}`\"

--- a/wine-tkg-git/win32-Initialize-params-for-WndProc-after-WH_CALLWNDPROC.mypatch
+++ b/wine-tkg-git/win32-Initialize-params-for-WndProc-after-WH_CALLWNDPROC.mypatch
@@ -1,23 +1,23 @@
-From 3a10dee2d48e214b8eb533f101c60e8fccc54f67 Mon Sep 17 00:00:00 2001
+From 378e8a7e8397d56f44e86de8b6511c1b0437b179 Mon Sep 17 00:00:00 2001
 From: llde <lorenzofersteam@live.it>
-Date: Wed, 13 Apr 2022 00:14:17 +0200
-Subject: [PATCH] Execute hooks callbacks even when init_window_call_params
- fail (No window procedure? ) .
+Date: Sun, 13 Nov 2022 22:13:32 +0100
+Subject: [PATCH] Execute WH_CALLWNDPROC before initializing param and execute
+ WH_CALLWNDPROCRET regardless of dispatch_win_proc_params
 
 ---
- dlls/win32u/message.c | 21 +++++++++------------
- 1 file changed, 9 insertions(+), 12 deletions(-)
+ dlls/win32u/message.c | 32 ++++++++++++++------------------
+ 1 file changed, 14 insertions(+), 18 deletions(-)
 
 diff --git a/dlls/win32u/message.c b/dlls/win32u/message.c
-index 9479595ae53..bac9d250d31 100644
+index 305397787b1..7e067bc13bd 100644
 --- a/dlls/win32u/message.c
 +++ b/dlls/win32u/message.c
-@@ -1179,30 +1179,27 @@ static LRESULT call_window_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lpar
+@@ -1340,41 +1340,37 @@ static LRESULT call_window_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lpar
      LRESULT result = 0;
      CWPSTRUCT cwp;
      CWPRETSTRUCT cwpret;
 -
-+    HWND win;
++    HWND win = win = get_full_window_handle( hwnd );
      if (msg & 0x80000000)
          return handle_internal_message( hwnd, msg, wparam, lparam );
  
@@ -30,36 +30,44 @@ index 9479595ae53..bac9d250d31 100644
 -        return 0;
 -    }
 -
--    params->needs_unpack = needs_unpack;
--    if (size) memcpy( params + 1, buffer, size );
-+    win = get_full_window_handle( hwnd );
- 
+-    if (needs_unpack)
+-    {
+-        params->needs_unpack = TRUE;
+-        params->ansi = FALSE;
+-        if (size) memcpy( params + 1, buffer, size );
+-    }
+-
      /* first the WH_CALLWNDPROC hook */
      cwp.lParam  = lparam;
      cwp.wParam  = wparam;
      cwp.message = msg;
 -    cwp.hwnd    = params->hwnd;
 +    cwp.hwnd    = win;
-     call_hooks( WH_CALLWNDPROC, HC_ACTION, same_thread, (LPARAM)&cwp, unicode );
- 
+     call_hooks( WH_CALLWNDPROC, HC_ACTION, same_thread, (LPARAM)&cwp, sizeof(cwp) );
+-
 -    dispatch_win_proc_params( params, sizeof(*params) + size );
-+    if (init_window_call_params( params, hwnd, msg, wparam, lparam, &result, !unicode, mapping )){
-+        params->needs_unpack = needs_unpack;
-+        if (size) memcpy( params + 1, buffer, size );
++    
++    if (init_window_call_params( params, hwnd, msg, wparam, lparam, &result, !unicode, mapping ))
++    {
++        if (needs_unpack)
++        {
++            params->needs_unpack = TRUE;
++            params->ansi = FALSE;
++            if (size) memcpy( params + 1, buffer, size );
++        }
 +        dispatch_win_proc_params( params, sizeof(*params) + size );
 +    }
-     if (params != &p) free( params );
  
      /* and finally the WH_CALLWNDPROCRET hook */
-@@ -1210,7 +1207,7 @@ static LRESULT call_window_proc( HWND hwnd, UINT msg, WPARAM wparam, LPARAM lpar
+     cwpret.lResult = result;
      cwpret.lParam  = lparam;
      cwpret.wParam  = wparam;
      cwpret.message = msg;
 -    cwpret.hwnd    = params->hwnd;
 +    cwpret.hwnd    = win;
-     call_hooks( WH_CALLWNDPROCRET, HC_ACTION, same_thread, (LPARAM)&cwpret, unicode );
-     return result;
- }
+ 
+     if (params != &p) free( params );
+ 
 -- 
-2.35.1
+2.38.1
 


### PR DESCRIPTION
Rebased 0001-Execute-hooks-callbacks-even-when-init_window_call_p.mypatch patchset for 7.20 and later, (renamed to win32-Initialize-params-for-WndProc-after-WH_CALLWNDPROC.mypatch as the old name wasn't actually describing the idea of the patch)
Also made server-Enable-link-time-optimization.mypatch applicable again (not sure if still have an effect)