### PR TITLE
Add some patches for VS2019 and IDA Pro

### DIFF
--- a/wine-tkg-git/0001-Allow-RtlSizeHeap-to-check-pointers-from-GlobalLock-staging.mypatch
+++ b/wine-tkg-git/0001-Allow-RtlSizeHeap-to-check-pointers-from-GlobalLock-staging.mypatch
@@ -12,44 +12,34 @@ diff --git a/dlls/ntdll/heap.c b/dlls/ntdll/heap.c
 index be75aa87b00..53c638abb4f 100644
 --- a/dlls/ntdll/heap.c
 +++ b/dlls/ntdll/heap.c
-@@ -2013,7 +2013,8 @@ SIZE_T WINAPI RtlSizeHeap( HANDLE heap, ULONG flags, const void *ptr )
-     const ARENA_INUSE *pArena;
+@@ -1962,3 +1962,5 @@ static NTSTATUS heap_size( HEAP *heap, const void *ptr, SIZE_T *size )
+     const ARENA_INUSE *block;
      SUBHEAP *subheap;
-     HEAP *heapPtr = HEAP_GetPtr( heap );
--
 +    BOOL GMEM_Work = FALSE;
 +    BOOL ArenaFound = FALSE;
-     if (!heapPtr)
-     {
-         RtlSetLastWin32ErrorAndNtStatusFromNtStatus( STATUS_INVALID_HANDLE );
-@@ -2024,8 +2025,18 @@ SIZE_T WINAPI RtlSizeHeap( HANDLE heap, ULONG flags, const void *ptr )
-     if (!(flags & HEAP_NO_SERIALIZE)) enter_critical_section( &heapPtr->critSection );
  
-     pArena = (const ARENA_INUSE *)ptr - 1;
--    if (!validate_block_pointer( heapPtr, &subheap, pArena ))
-+    ArenaFound = validate_block_pointer( heapPtr, &subheap, pArena );
+@@ -1965,4 +1967,12 @@ static NTSTATUS heap_size( HEAP *heap, const void *ptr, SIZE_T *size )
+     block = (const ARENA_INUSE *)ptr - 1;
+-    if (!validate_block_pointer( heap, &subheap, block )) return STATUS_INVALID_PARAMETER;
++    ArenaFound = validate_block_pointer( heap, &subheap, block );
 +    if(ArenaFound == FALSE){
-+        pArena = (const ARENA_INUSE*) ((const char*) pArena - sizeof(HGLOBAL)*2);
-+        if((ArenaFound = validate_block_pointer( heapPtr, &subheap, pArena))){
++        block = (const ARENA_INUSE*) ((const char*) block - sizeof(HGLOBAL)*2);
++        if((ArenaFound = validate_block_pointer( heap, &subheap, block))){
 +            FIXME("GMEM_MOVEABLE GlobalMemory workaround\n");
 +            GMEM_Work = TRUE;
 +        }
 +    }
-+
-+    if (!ArenaFound)
++    if(ArenaFound == FALSE) return STATUS_INVALID_PARAMETER;    
+     if (!subheap)
      {
-+        FIXME("Failed validate arena %p %p %p \n",heapPtr, heap, pArena);
-         RtlSetLastWin32ErrorAndNtStatusFromNtStatus( STATUS_INVALID_PARAMETER );
-         ret = ~(SIZE_T)0;
+@@ -1972,8 +1982,9 @@ static NTSTATUS heap_size( HEAP *heap, const void *ptr, SIZE_T *size )
+     else
+     {
+         *size = (block->size & ARENA_SIZE_MASK) - block->unused_bytes;
      }
-@@ -2039,8 +2050,7 @@ SIZE_T WINAPI RtlSizeHeap( HANDLE heap, ULONG flags, const void *ptr )
-         ret = (pArena->size & ARENA_SIZE_MASK) - pArena->unused_bytes;
-     }
-     if (!(flags & HEAP_NO_SERIALIZE)) leave_critical_section( &heapPtr->critSection );
--
--    TRACE("(%p,%08x,%p): returning %08lx\n", heap, flags, ptr, ret );
-+    if(GMEM_Work) ret -= sizeof(HGLOBAL)*2;
-     return ret;
+ 
++    if(GMEM_Work) *size -= sizeof(HGLOBAL)*2;
+     return STATUS_SUCCESS;
  }
  
 -- 

--- a/wine-tkg-git/Proper_refcount_forwarded_exports.mypatch
+++ b/wine-tkg-git/Proper_refcount_forwarded_exports.mypatch
@@ -1,0 +1,582 @@
+From: Jinoh Kang <jinoh.kang.kr@gmail.com>
+Subject: [PATCH v11 1/2] kernel32/tests: Test module refcounting with forwarded exports.
+Message-Id: <a6c28b1e-4a89-0aee-3365-238182f80cbf@gmail.com>
+Date: Tue, 1 Mar 2022 22:53:37 +0900
+
+Signed-off-by: Jinoh Kang <jinoh.kang.kr@gmail.com>
+---
+
+Notes:
+    v3 -> v4:
+    - iatgas.h
+      - LLVM(Clang), ARM, ARM64 support
+      - Use __ASM_NAME macro
+      - Don't fail test on MSVC
+      - Don't end asm macros with "\n\t"
+    
+    v4 -> v5:
+    - iatgas.h
+      - mark idata sections as RO
+    - loader.c
+      - test for forward export itself
+    
+    v5 -> v6:
+    - loader.c
+      - Fix compilation warning in format string
+    
+    v6 -> v7:
+    - forward4.c
+      - fix building without MinGW
+    
+    v7 -> v8:
+    - Also do GetProcAddress for forwarded ordinal exports
+    - forward[1-3].c
+      - Call DisableThreadLibraryCalls in DllMain
+    - forward4.c: removed
+    - iatgas.h: removed
+    - sforward.c: new file
+    - loader.c
+      - test static forwarded import using shlwapi -> userenv forward
+    
+    v8 -> v9:
+    - Test with iprop (documented as an ole32 forwarder in MSDN [1])
+    
+    v9 -> v10:
+    - Test with icmp instead (documented as an iphlpapi forwarder in MSDN [2])
+    
+    v10 -> v11:
+    - rebase onto latest version
+    
+    [1] https://docs.microsoft.com/en-us/windows/win32/api/coml2api/nf-coml2api-stgopenpropstg
+    [2] https://docs.microsoft.com/en-us/windows/win32/api/icmpapi/nf-icmpapi-icmpcreatefile
+
+ dlls/icmp/Makefile.in             |   1 +
+ dlls/kernel32/tests/Makefile.in   |  14 ++-
+ dlls/kernel32/tests/forward1.c    |  19 ++++
+ dlls/kernel32/tests/forward1.spec |   2 +
+ dlls/kernel32/tests/forward2.c    |   9 ++
+ dlls/kernel32/tests/forward2.spec |   2 +
+ dlls/kernel32/tests/forward3.c    |   9 ++
+ dlls/kernel32/tests/forward3.spec |   2 +
+ dlls/kernel32/tests/loader.c      | 182 ++++++++++++++++++++++++++++++
+ dlls/kernel32/tests/sforward.c    |  18 +++
+ dlls/kernel32/tests/sforward.spec |   1 +
+ 11 files changed, 257 insertions(+), 2 deletions(-)
+ create mode 100644 dlls/kernel32/tests/forward1.c
+ create mode 100644 dlls/kernel32/tests/forward1.spec
+ create mode 100644 dlls/kernel32/tests/forward2.c
+ create mode 100644 dlls/kernel32/tests/forward2.spec
+ create mode 100644 dlls/kernel32/tests/forward3.c
+ create mode 100644 dlls/kernel32/tests/forward3.spec
+ create mode 100644 dlls/kernel32/tests/sforward.c
+ create mode 100644 dlls/kernel32/tests/sforward.spec
+
+diff --git a/dlls/icmp/Makefile.in b/dlls/icmp/Makefile.in
+index 11111111111..11111111111 100644
+--- a/dlls/icmp/Makefile.in
++++ b/dlls/icmp/Makefile.in
+@@ -1,3 +1,4 @@
+ MODULE    = icmp.dll
++IMPORTLIB = icmp
+ 
+ EXTRADLLFLAGS = -Wb,--data-only
+diff --git a/dlls/kernel32/tests/Makefile.in b/dlls/kernel32/tests/Makefile.in
+index 11111111111..11111111111 100644
+--- a/dlls/kernel32/tests/Makefile.in
++++ b/dlls/kernel32/tests/Makefile.in
+@@ -1,5 +1,7 @@
+ TESTDLL   = kernel32.dll
+-IMPORTS   = user32 advapi32
++
++# icmp is for testing export forwarding (to iphlpapi)
++IMPORTS   = user32 advapi32 icmp
+ 
+ SOURCES = \
+ 	actctx.c \
+@@ -37,4 +39,12 @@ SOURCES = \
+ 	toolhelp.c \
+ 	version.c \
+ 	virtual.c \
+-	volume.c
++	volume.c \
++	forward1.c \
++	forward1.spec \
++	forward2.c \
++	forward2.spec \
++	forward3.c \
++	forward3.spec \
++	sforward.c \
++	sforward.spec
+diff --git a/dlls/kernel32/tests/forward1.c b/dlls/kernel32/tests/forward1.c
+new file mode 100644
+index 00000000000..11111111111
+--- /dev/null
++++ b/dlls/kernel32/tests/forward1.c
+@@ -0,0 +1,19 @@
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++
++BOOL WINAPI DllMain(HINSTANCE instance_new, DWORD reason, LPVOID reserved)
++{
++    if (reason == DLL_PROCESS_ATTACH)
++        DisableThreadLibraryCalls( instance_new );
++    return TRUE;
++}
++
++unsigned long forward_test_func(void)
++{
++    return 0x00005678UL;
++}
++
++unsigned long forward_test_func2(void)
++{
++    return 0x12340000UL;
++}
+diff --git a/dlls/kernel32/tests/forward1.spec b/dlls/kernel32/tests/forward1.spec
+new file mode 100644
+index 00000000000..11111111111
+--- /dev/null
++++ b/dlls/kernel32/tests/forward1.spec
+@@ -0,0 +1,2 @@
++1 cdecl forward_test_func()
++2 cdecl -noname forward_test_func2()
+diff --git a/dlls/kernel32/tests/forward2.c b/dlls/kernel32/tests/forward2.c
+new file mode 100644
+index 00000000000..11111111111
+--- /dev/null
++++ b/dlls/kernel32/tests/forward2.c
+@@ -0,0 +1,9 @@
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++
++BOOL WINAPI DllMain(HINSTANCE instance_new, DWORD reason, LPVOID reserved)
++{
++    if (reason == DLL_PROCESS_ATTACH)
++        DisableThreadLibraryCalls( instance_new );
++    return TRUE;
++}
+diff --git a/dlls/kernel32/tests/forward2.spec b/dlls/kernel32/tests/forward2.spec
+new file mode 100644
+index 00000000000..11111111111
+--- /dev/null
++++ b/dlls/kernel32/tests/forward2.spec
+@@ -0,0 +1,2 @@
++1 cdecl forward_test_func() forward1.forward_test_func
++2 cdecl -noname forward_test_func2() forward1.#2
+diff --git a/dlls/kernel32/tests/forward3.c b/dlls/kernel32/tests/forward3.c
+new file mode 100644
+index 00000000000..11111111111
+--- /dev/null
++++ b/dlls/kernel32/tests/forward3.c
+@@ -0,0 +1,9 @@
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++
++BOOL WINAPI DllMain(HINSTANCE instance_new, DWORD reason, LPVOID reserved)
++{
++    if (reason == DLL_PROCESS_ATTACH)
++        DisableThreadLibraryCalls( instance_new );
++    return TRUE;
++}
+diff --git a/dlls/kernel32/tests/forward3.spec b/dlls/kernel32/tests/forward3.spec
+new file mode 100644
+index 00000000000..11111111111
+--- /dev/null
++++ b/dlls/kernel32/tests/forward3.spec
+@@ -0,0 +1,2 @@
++1 cdecl forward_test_func() forward2.forward_test_func
++2 cdecl -noname forward_test_func2() forward2.#2
+diff --git a/dlls/kernel32/tests/loader.c b/dlls/kernel32/tests/loader.c
+index 11111111111..11111111111 100644
+--- a/dlls/kernel32/tests/loader.c
++++ b/dlls/kernel32/tests/loader.c
+@@ -1643,6 +1643,185 @@ static void test_ImportDescriptors(void)
+     }
+ }
+ 
++static void extract_resource(const char *name, const char *type, const char *path)
++{
++    DWORD written;
++    HANDLE file;
++    HRSRC res;
++    void *ptr;
++
++    file = CreateFileA(path, GENERIC_READ|GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, 0);
++    ok(file != INVALID_HANDLE_VALUE, "file creation failed, at %s, error %d\n", path, GetLastError());
++
++    res = FindResourceA(NULL, name, type);
++    ok( res != 0, "couldn't find resource\n" );
++    ptr = LockResource( LoadResource( GetModuleHandleA(NULL), res ));
++    WriteFile( file, ptr, SizeofResource( GetModuleHandleA(NULL), res ), &written, NULL );
++    ok( written == SizeofResource( GetModuleHandleA(NULL), res ), "couldn't write resource\n" );
++    CloseHandle( file );
++}
++
++static void test_static_forwarded_import_refs(void)
++{
++    CHAR temp_path[MAX_PATH], dir_path[MAX_PATH], sforward_path[MAX_PATH];
++    HMODULE iphlpapi, icmp, sforward;
++    FARPROC test_func_stub;
++
++    if (GetModuleHandleA( "iphlpapi.dll" ))
++    {
++        skip("cannot test since iphlpapi.dll is already loaded\n");
++        return;
++    }
++    if (GetModuleHandleA( "icmp.dll" ))
++    {
++        skip("cannot test since icmp.dll is already loaded\n");
++        return;
++    }
++
++    GetTempPathA( ARRAY_SIZE(temp_path), temp_path );
++    GetTempFileNameA( temp_path, "ldr", GetTickCount() | 1UL, dir_path );
++    ok( CreateDirectoryA( dir_path, NULL ), "failed to create dir %s, error %u\n",
++        dir_path, GetLastError() );
++
++    snprintf( sforward_path, MAX_PATH, "%s\\sforward.dll", dir_path );
++    extract_resource( "sforward.dll", "TESTDLL", sforward_path );
++
++    iphlpapi = LoadLibraryA( "iphlpapi.dll" );
++    ok( !!iphlpapi, "couldn't find iphlpapi.dll: %u\n", GetLastError() );
++    icmp = LoadLibraryA( "icmp.dll" );
++    ok( !!icmp, "couldn't find icmp.dll: %u\n", GetLastError() );
++    sforward = LoadLibraryA( sforward_path );
++    ok( !!sforward, "couldn't find %s: %u\n", sforward_path, GetLastError() );
++
++    test_func_stub = GetProcAddress( sforward, "test_func_stub" );
++    ok( !!test_func_stub, "sforward!test_func_stub not found\n" );
++
++    FreeLibrary( iphlpapi );
++    FreeLibrary( icmp );
++
++    todo_wine
++    ok( !!GetModuleHandleA( "iphlpapi.dll" ), "iphlpapi.dll unexpectedly unloaded\n" );
++    ok( !!GetModuleHandleA( "icmp.dll" ), "icmp.dll unexpectedly unloaded\n" );
++
++    FreeLibrary( sforward );
++
++    ok( !GetModuleHandleA( "iphlpapi.dll" ), "iphlpapi.dll unexpectedly kept open\n" );
++    ok( !GetModuleHandleA( "icmp.dll" ), "icmp.dll unexpectedly kept open\n" );
++    ok( !GetModuleHandleA( "sforward.dll" ), "sforward.dll unexpectedly kept open\n" );
++
++    DeleteFileA( sforward_path );
++    RemoveDirectoryA( dir_path );
++}
++
++static void test_dynamic_forwarded_import_refs(void)
++{
++    CHAR temp_path[MAX_PATH], dir_path[MAX_PATH];
++    CHAR forward1_path[MAX_PATH];
++    CHAR forward2_path[MAX_PATH];
++    CHAR forward3_path[MAX_PATH];
++    HMODULE forward1, forward2, forward3;
++    FARPROC proc1, proc2, proc3, oproc1, oproc2, oproc3;
++
++    GetTempPathA( ARRAY_SIZE(temp_path), temp_path );
++    GetTempFileNameA( temp_path, "ldr", GetTickCount() | 1UL, dir_path );
++    ok( CreateDirectoryA( dir_path, NULL ), "failed to create dir %s, error %u\n",
++        dir_path, GetLastError() );
++
++    snprintf( forward1_path, MAX_PATH, "%s\\forward1.dll", dir_path );
++    snprintf( forward2_path, MAX_PATH, "%s\\forward2.dll", dir_path );
++    snprintf( forward3_path, MAX_PATH, "%s\\forward3.dll", dir_path );
++    extract_resource( "forward1.dll", "TESTDLL", forward1_path );
++    extract_resource( "forward2.dll", "TESTDLL", forward2_path );
++    extract_resource( "forward3.dll", "TESTDLL", forward3_path );
++
++    forward1 = LoadLibraryA( forward1_path );
++    ok( !!forward1, "couldn't find %s: %u\n", forward1_path, GetLastError() );
++    forward2 = LoadLibraryA( forward2_path );
++    ok( !!forward2, "couldn't find %s: %u\n", forward2_path, GetLastError() );
++    forward3 = LoadLibraryA( forward3_path );
++    ok( !!forward3, "couldn't find %s: %u\n", forward3_path, GetLastError() );
++
++    proc1 = GetProcAddress(forward1, "forward_test_func");
++    ok( !!proc1, "cannot resolve forward1!forward_test_func\n");
++    proc2 = GetProcAddress(forward2, "forward_test_func");
++    ok( !!proc2, "cannot resolve forward2!forward_test_func\n");
++    proc3 = GetProcAddress(forward3, "forward_test_func");
++    ok( !!proc3, "cannot resolve forward3!forward_test_func\n");
++    ok( proc1 == proc3, "forward1!forward_test_func is not equal to forward3!forward_test_func\n");
++    ok( proc2 == proc3, "forward2!forward_test_func is not equal to forward3!forward_test_func\n");
++
++    oproc1 = GetProcAddress(forward1, (LPSTR)2);
++    ok( !!oproc1, "cannot resolve forward1!#2 (forward_test_func2)\n");
++    oproc2 = GetProcAddress(forward2, (LPSTR)2);
++    ok( !!oproc2, "cannot resolve forward2!#2 (forward_test_func2)\n");
++    oproc3 = GetProcAddress(forward3, (LPSTR)2);
++    ok( !!oproc3, "cannot resolve forward3!#2 (forward_test_func2)\n");
++    ok( oproc1 == oproc3, "forward1!forward_test_func2 is not equal to forward3!forward_test_func2\n");
++    ok( oproc2 == oproc3, "forward2!forward_test_func2 is not equal to forward3!forward_test_func2\n");
++
++    FreeLibrary( forward1 );
++    FreeLibrary( forward2 );
++
++    todo_wine
++    ok( !!GetModuleHandleA( "forward1.dll" ), "forward1.dll unexpectedly unloaded\n" );
++    todo_wine
++    ok( !!GetModuleHandleA( "forward2.dll" ), "forward2.dll unexpectedly unloaded\n" );
++
++    FreeLibrary( forward3 );
++
++    ok( !GetModuleHandleA( "forward1.dll" ), "forward1.dll unexpectedly kept open\n" );
++    ok( !GetModuleHandleA( "forward2.dll" ), "forward2.dll unexpectedly kept open\n" );
++    ok( !GetModuleHandleA( "forward3.dll" ), "forward3.dll unexpectedly kept open\n" );
++
++    DeleteFileA( forward1_path );
++    DeleteFileA( forward2_path );
++    DeleteFileA( forward3_path );
++    RemoveDirectoryA( dir_path );
++}
++
++static void test_dynamic_forward_export_norefs(void)
++{
++    CHAR temp_path[MAX_PATH], dir_path[MAX_PATH];
++    CHAR forward1_path[MAX_PATH];
++    CHAR forward2_path[MAX_PATH];
++    CHAR forward3_path[MAX_PATH];
++    HMODULE forward1, forward2, forward3;
++
++    GetTempPathA( ARRAY_SIZE(temp_path), temp_path );
++    GetTempFileNameA( temp_path, "ldr", GetTickCount() | 1UL, dir_path );
++    ok( CreateDirectoryA( dir_path, NULL ), "failed to create dir %s, error %u\n",
++        dir_path, GetLastError() );
++
++    snprintf( forward1_path, MAX_PATH, "%s\\forward1.dll", dir_path );
++    snprintf( forward2_path, MAX_PATH, "%s\\forward2.dll", dir_path );
++    snprintf( forward3_path, MAX_PATH, "%s\\forward3.dll", dir_path );
++    extract_resource( "forward1.dll", "TESTDLL", forward1_path );
++    extract_resource( "forward2.dll", "TESTDLL", forward2_path );
++    extract_resource( "forward3.dll", "TESTDLL", forward3_path );
++
++    forward1 = LoadLibraryA( forward1_path );
++    ok( !!forward1, "couldn't find %s: %u\n", forward1_path, GetLastError() );
++    forward2 = LoadLibraryA( forward2_path );
++    ok( !!forward2, "couldn't find %s: %u\n", forward2_path, GetLastError() );
++    forward3 = LoadLibraryA( forward3_path );
++    ok( !!forward3, "couldn't find %s: %u\n", forward3_path, GetLastError() );
++
++    FreeLibrary( forward1 );
++    FreeLibrary( forward3 );
++
++    ok( !GetModuleHandleA( "forward1.dll" ), "forward1.dll unexpectedly kept open\n" );
++    ok( !GetModuleHandleA( "forward3.dll" ), "forward3.dll unexpectedly kept open\n" );
++
++    FreeLibrary( forward2 );
++
++    ok( !GetModuleHandleA( "forward2.dll" ), "forward2.dll unexpectedly kept open\n" );
++
++    DeleteFileA( forward1_path );
++    DeleteFileA( forward2_path );
++    DeleteFileA( forward3_path );
++    RemoveDirectoryA( dir_path );
++}
++
+ static void test_image_mapping(const char *dll_name, DWORD scn_page_access, BOOL is_dll)
+ {
+     HANDLE hfile, hmap;
+@@ -4193,9 +4372,12 @@ START_TEST(loader)
+         return;
+     }
+ 
++    test_static_forwarded_import_refs();  /* Must be first; other tests may load iphlpapi.dll */
+     test_filenames();
+     test_ResolveDelayLoadedAPI();
+     test_ImportDescriptors();
++    test_dynamic_forwarded_import_refs();
++    test_dynamic_forward_export_norefs();
+     test_section_access();
+     test_import_resolution();
+     test_ExitProcess();
+diff --git a/dlls/kernel32/tests/sforward.c b/dlls/kernel32/tests/sforward.c
+new file mode 100644
+index 00000000000..11111111111
+--- /dev/null
++++ b/dlls/kernel32/tests/sforward.c
+@@ -0,0 +1,18 @@
++#define WIN32_LEAN_AND_MEAN
++#include <windows.h>
++#include <ws2tcpip.h>
++#include <iphlpapi.h>
++#include <icmpapi.h>
++
++void test_func_stub(void)
++{
++    HANDLE file = IcmpCreateFile();
++    if (file != INVALID_HANDLE_VALUE) IcmpCloseHandle( file );
++}
++
++BOOL WINAPI DllMain(HINSTANCE instance_new, DWORD reason, LPVOID reserved)
++{
++    if (reason == DLL_PROCESS_ATTACH)
++        DisableThreadLibraryCalls( instance_new );
++    return TRUE;
++}
+diff --git a/dlls/kernel32/tests/sforward.spec b/dlls/kernel32/tests/sforward.spec
+new file mode 100644
+index 00000000000..11111111111
+--- /dev/null
++++ b/dlls/kernel32/tests/sforward.spec
+@@ -0,0 +1 @@
++@ cdecl test_func_stub()
+
+-- 
+2.37.2From: Jinoh Kang <jinoh.kang.kr@gmail.com>
+Subject: [PATCH v11 2/2] ntdll: Properly track refcount with forwarded exports.
+Message-Id: <8f975196-6271-523e-2098-99bc90495cf8@gmail.com>
+Date: Tue, 1 Mar 2022 22:54:25 +0900
+In-Reply-To: <a6c28b1e-4a89-0aee-3365-238182f80cbf@gmail.com>
+References: <a6c28b1e-4a89-0aee-3365-238182f80cbf@gmail.com>
+
+Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=52094
+Signed-off-by: Jinoh Kang <jinoh.kang.kr@gmail.com>
+---
+
+Notes:
+    v10 -> v11:
+    - rebase onto latest version
+
+ dlls/kernel32/tests/loader.c |  3 --
+ dlls/ntdll/loader.c          | 69 ++++++++++++++++++++----------------
+ 2 files changed, 39 insertions(+), 33 deletions(-)
+
+diff --git a/dlls/kernel32/tests/loader.c b/dlls/kernel32/tests/loader.c
+index 11111111111..11111111111 100644
+--- a/dlls/kernel32/tests/loader.c
++++ b/dlls/kernel32/tests/loader.c
+@@ -1699,7 +1699,6 @@ static void test_static_forwarded_import_refs(void)
+     FreeLibrary( iphlpapi );
+     FreeLibrary( icmp );
+ 
+-    todo_wine
+     ok( !!GetModuleHandleA( "iphlpapi.dll" ), "iphlpapi.dll unexpectedly unloaded\n" );
+     ok( !!GetModuleHandleA( "icmp.dll" ), "icmp.dll unexpectedly unloaded\n" );
+ 
+@@ -1762,9 +1761,7 @@ static void test_dynamic_forwarded_import_refs(void)
+     FreeLibrary( forward1 );
+     FreeLibrary( forward2 );
+ 
+-    todo_wine
+     ok( !!GetModuleHandleA( "forward1.dll" ), "forward1.dll unexpectedly unloaded\n" );
+-    todo_wine
+     ok( !!GetModuleHandleA( "forward2.dll" ), "forward2.dll unexpectedly unloaded\n" );
+ 
+     FreeLibrary( forward3 );
+diff --git a/dlls/ntdll/loader.c b/dlls/ntdll/loader.c
+index 11111111111..11111111111 100644
+--- a/dlls/ntdll/loader.c
++++ b/dlls/ntdll/loader.c
+@@ -996,7 +996,7 @@ static FARPROC find_forwarded_export( HMODULE module, const char *forward, LPCWS
+ {
+     const IMAGE_EXPORT_DIRECTORY *exports;
+     DWORD exp_size;
+-    WINE_MODREF *wm;
++    WINE_MODREF *wm = NULL, *imp;
+     WCHAR mod_name[256];
+     const char *end = strrchr(forward, '.');
+     FARPROC proc = NULL;
+@@ -1004,30 +1004,24 @@ static FARPROC find_forwarded_export( HMODULE module, const char *forward, LPCWS
+     if (!end) return NULL;
+     if (build_import_name( mod_name, forward, end - forward )) return NULL;
+ 
+-    if (!(wm = find_basename_module( mod_name )))
++    imp = get_modref( module );
++    TRACE( "delay loading %s for '%s'\n", debugstr_w(mod_name), forward );
++    if (load_dll( load_path, mod_name, 0, &wm, imp->system ) == STATUS_SUCCESS &&
++        !(wm->ldr.Flags & LDR_DONT_RESOLVE_REFS))
+     {
+-        WINE_MODREF *imp = get_modref( module );
+-        TRACE( "delay loading %s for '%s'\n", debugstr_w(mod_name), forward );
+-        if (load_dll( load_path, mod_name, 0, &wm, imp->system ) == STATUS_SUCCESS &&
+-            !(wm->ldr.Flags & LDR_DONT_RESOLVE_REFS))
++        if ((imports_fixup_done || !current_modref) &&
++            process_attach( wm->ldr.DdagNode, NULL ) != STATUS_SUCCESS)
+         {
+-            if (!imports_fixup_done && current_modref)
+-            {
+-                add_module_dependency( current_modref->ldr.DdagNode, wm->ldr.DdagNode );
+-            }
+-            else if (process_attach( wm->ldr.DdagNode, NULL ) != STATUS_SUCCESS)
+-            {
+-                LdrUnloadDll( wm->ldr.DllBase );
+-                wm = NULL;
+-            }
++            LdrUnloadDll( wm->ldr.DllBase );
++            wm = NULL;
+         }
++    }
+ 
+-        if (!wm)
+-        {
+-            ERR( "module not found for forward '%s' used by %s\n",
+-                 forward, debugstr_w(imp->ldr.FullDllName.Buffer) );
+-            return NULL;
+-        }
++    if (!wm)
++    {
++        ERR( "module not found for forward '%s' used by %s\n",
++             forward, debugstr_w(imp->ldr.FullDllName.Buffer) );
++        return NULL;
+     }
+     if ((exports = RtlImageDirectoryEntryToData( wm->ldr.DllBase, TRUE,
+                                                  IMAGE_DIRECTORY_ENTRY_EXPORT, &exp_size )))
+@@ -1047,6 +1041,11 @@ static FARPROC find_forwarded_export( HMODULE module, const char *forward, LPCWS
+             " If you are using builtin %s, try using the native one instead.\n",
+             forward, debugstr_w(get_modref(module)->ldr.FullDllName.Buffer),
+             debugstr_w(get_modref(module)->ldr.BaseDllName.Buffer) );
++        if (wm) LdrUnloadDll( wm->ldr.DllBase );
++    }
++    else if (current_modref)
++    {
++        add_module_dependency( current_modref->ldr.DdagNode, wm->ldr.DdagNode );
+     }
+     return proc;
+ }
+@@ -2203,21 +2202,31 @@ NTSTATUS WINAPI LdrGetProcedureAddress(HMODULE module, const ANSI_STRING *name,
+     IMAGE_EXPORT_DIRECTORY *exports;
+     DWORD exp_size;
+     NTSTATUS ret = STATUS_PROCEDURE_NOT_FOUND;
++    WINE_MODREF *prev, *wm;
+ 
+     RtlEnterCriticalSection( &loader_section );
+ 
+-    /* check if the module itself is invalid to return the proper error */
+-    if (!get_modref( module )) ret = STATUS_DLL_NOT_FOUND;
+-    else if ((exports = RtlImageDirectoryEntryToData( module, TRUE,
+-                                                      IMAGE_DIRECTORY_ENTRY_EXPORT, &exp_size )))
++    wm = get_modref( module );
++    if (!wm) ret = STATUS_DLL_NOT_FOUND;
++    else
+     {
+-        void *proc = name ? find_named_export( module, exports, exp_size, name->Buffer, -1, NULL )
+-                          : find_ordinal_export( module, exports, exp_size, ord - exports->Base, NULL );
+-        if (proc && !is_hidden_export( proc ))
++        prev = current_modref;
++        current_modref = wm;
++
++        /* check if the module itself is invalid to return the proper error */
++        if ((exports = RtlImageDirectoryEntryToData( module, TRUE,
++                                                     IMAGE_DIRECTORY_ENTRY_EXPORT, &exp_size )))
+         {
+-            *address = proc;
+-            ret = STATUS_SUCCESS;
++            void *proc = name ? find_named_export( module, exports, exp_size, name->Buffer, -1, NULL )
++                              : find_ordinal_export( module, exports, exp_size, ord - exports->Base, NULL );
++            if (proc && !is_hidden_export( proc ))
++            {
++                *address = proc;
++                ret = STATUS_SUCCESS;
++            }
+         }
++
++        current_modref = prev;
+     }
+ 
+     RtlLeaveCriticalSection( &loader_section );
+
+-- 
+2.37.2
+
+
+

--- a/wine-tkg-git/README.md
+++ b/wine-tkg-git/README.md
@@ -69,3 +69,5 @@
 - 0001-Revert-server-Handle-the-entire-IOCTL_AFD_POLL-ioctl.mypatch : Revert the commit that moved IOCTL_AFD_POLL serverside. Rustup (and possible other application that use this routine) need this revert to properly park/unpark the thread.
 - win32-Initialize-params-for-WndProc-after-WH_CALLWNDPROC.mypatch : Initalize parameters for WndProc procedure after WH_CALLWNDPROC hook is called. (Required )
 - 0001-Force-full-erase-when-WM_PAINT-in-LVS_EX_DOUBLEBUFFE.mypatch : Force a background erase on LVS_EX_DOUBLEBUFFERED listviews. Fix black background for listviews on some apps.
+- VisualStudio2019_patches.mypatch : A series of patches for a working installation of Visual Studio 2019
+- Proper_refcount_forwarded_exports.mypatch : Allow forwarded exports to properly tracks their refcounts, avoiding spuruious DLL unloading. Needed for IDA Pro IDAPython3 

--- a/wine-tkg-git/VisualStudio2019_patches.mypatch
+++ b/wine-tkg-git/VisualStudio2019_patches.mypatch
@@ -1,0 +1,520 @@
+diff --git a/dlls/kernelbase/registry.c b/dlls/kernelbase/registry.c
+index 30c5e9f6f3..d1fba99b05 100644
+--- a/dlls/kernelbase/registry.c
++++ b/dlls/kernelbase/registry.c
+@@ -3046,8 +3046,7 @@ LSTATUS WINAPI RegLoadAppKeyA(const char *file, HKEY *result, REGSAM sam, DWORD
+     if (!file || reserved)
+         return ERROR_INVALID_PARAMETER;
+ 
+-    *result = (HKEY)0xdeadbeef;
+-    return ERROR_SUCCESS;
++    return RegOpenKeyExA(HKEY_CURRENT_USER, "", KEY_ALL_ACCESS, 0, result);
+ }
+ 
+ /******************************************************************************
+@@ -3061,8 +3060,7 @@ LSTATUS WINAPI RegLoadAppKeyW(const WCHAR *file, HKEY *result, REGSAM sam, DWORD
+     if (!file || reserved)
+         return ERROR_INVALID_PARAMETER;
+ 
+-    *result = (HKEY)0xdeadbeef;
+-    return ERROR_SUCCESS;
++    return RegOpenKeyExW(HKEY_CURRENT_USER, L"", KEY_ALL_ACCESS, 0, result);
+ }
+ 
+ /******************************************************************************
+
+From d013a97e453e16f8a4622628835011715308716e Mon Sep 17 00:00:00 2001
+From: llde <lorenzofersteam@live.it>
+Date: Tue, 23 May 2023 00:05:34 +0200
+Subject: [PATCH] Add CS debug info to Critical Section involved in VS2019
+ deadlock
+
+---
+ dlls/ole32/moniker.c | 48 ++++++++++++++++++++++++++------------------
+ 1 file changed, 29 insertions(+), 19 deletions(-)
+
+diff --git a/dlls/ole32/moniker.c b/dlls/ole32/moniker.c
+index ec026758b2f..f2668a1edbf 100644
+--- a/dlls/ole32/moniker.c
++++ b/dlls/ole32/moniker.c
+@@ -66,7 +66,7 @@ typedef struct RunningObjectTableImpl
+ {
+     IRunningObjectTable IRunningObjectTable_iface;
+     struct list rot; /* list of ROT entries */
+-    CRITICAL_SECTION lock;
++    CRITICAL_SECTION* lock;
+ } RunningObjectTableImpl;
+ 
+ /* define the EnumMonikerImpl structure */
+@@ -417,9 +417,9 @@ RunningObjectTableImpl_Register(IRunningObjectTable* iface, DWORD flags,
+     /* gives a registration identifier to the registered object*/
+     *pdwRegister = rot_entry->cookie;
+ 
+-    EnterCriticalSection(&This->lock);
++    EnterCriticalSection(This->lock);
+     list_add_tail(&This->rot, &rot_entry->entry);
+-    LeaveCriticalSection(&This->lock);
++    LeaveCriticalSection(This->lock);
+ 
+     return hr;
+ }
+@@ -438,19 +438,19 @@ RunningObjectTableImpl_Revoke( IRunningObjectTable* iface, DWORD dwRegister)
+ 
+     TRACE("%p, %ld.\n", iface, dwRegister);
+ 
+-    EnterCriticalSection(&This->lock);
++    EnterCriticalSection(This->lock);
+     LIST_FOR_EACH_ENTRY(rot_entry, &This->rot, struct rot_entry, entry)
+     {
+         if (rot_entry->cookie == dwRegister)
+         {
+             list_remove(&rot_entry->entry);
+-            LeaveCriticalSection(&This->lock);
++            LeaveCriticalSection(This->lock);
+ 
+             rot_entry_delete(rot_entry);
+             return S_OK;
+         }
+     }
+-    LeaveCriticalSection(&This->lock);
++    LeaveCriticalSection(This->lock);
+ 
+     return E_INVALIDARG;
+ }
+@@ -480,7 +480,7 @@ RunningObjectTableImpl_IsRunning( IRunningObjectTable* iface, IMoniker *pmkObjec
+         return hr;
+ 
+     hr = S_FALSE;
+-    EnterCriticalSection(&This->lock);
++    EnterCriticalSection(This->lock);
+     LIST_FOR_EACH_ENTRY(rot_entry, &This->rot, const struct rot_entry, entry)
+     {
+         if ((rot_entry->moniker_data->ulCntData == moniker_data->ulCntData) &&
+@@ -490,7 +490,7 @@ RunningObjectTableImpl_IsRunning( IRunningObjectTable* iface, IMoniker *pmkObjec
+             break;
+         }
+     }
+-    LeaveCriticalSection(&This->lock);
++    LeaveCriticalSection(This->lock);
+ 
+     if (hr == S_FALSE)
+         hr = InternalIrotIsRunning(moniker_data);
+@@ -533,7 +533,7 @@ RunningObjectTableImpl_GetObject( IRunningObjectTable* iface,
+     if (hr != S_OK)
+         return hr;
+ 
+-    EnterCriticalSection(&This->lock);
++    EnterCriticalSection(This->lock);
+     LIST_FOR_EACH_ENTRY(rot_entry, &This->rot, struct rot_entry, entry)
+     {
+         if ((rot_entry->moniker_data->ulCntData == moniker_data->ulCntData) &&
+@@ -547,13 +547,13 @@ RunningObjectTableImpl_GetObject( IRunningObjectTable* iface,
+                 IStream_Release(pStream);
+             }
+ 
+-            LeaveCriticalSection(&This->lock);
++            LeaveCriticalSection(This->lock);
+             HeapFree(GetProcessHeap(), 0, moniker_data);
+ 
+             return hr;
+         }
+     }
+-    LeaveCriticalSection(&This->lock);
++    LeaveCriticalSection(This->lock);
+ 
+     TRACE("moniker unavailable locally, calling SCM\n");
+ 
+@@ -593,20 +593,20 @@ RunningObjectTableImpl_NoteChangeTime(IRunningObjectTable* iface,
+ 
+     TRACE("%p, %ld, %p.\n", iface, dwRegister, pfiletime);
+ 
+-    EnterCriticalSection(&This->lock);
++    EnterCriticalSection(This->lock);
+     LIST_FOR_EACH_ENTRY(rot_entry, &This->rot, struct rot_entry, entry)
+     {
+         if (rot_entry->cookie == dwRegister)
+         {
+             rot_entry->last_modified = *pfiletime;
+-            LeaveCriticalSection(&This->lock);
++            LeaveCriticalSection(This->lock);
+ 
+             hr = InternalIrotNoteChangeTime(dwRegister, pfiletime);
+ 
+             goto done;
+         }
+     }
+-    LeaveCriticalSection(&This->lock);
++    LeaveCriticalSection(This->lock);
+ 
+ done:
+     TRACE("-- %#lx\n", hr);
+@@ -644,7 +644,7 @@ RunningObjectTableImpl_GetTimeOfLastChange(IRunningObjectTable* iface,
+ 
+     hr = MK_E_UNAVAILABLE;
+ 
+-    EnterCriticalSection(&This->lock);
++    EnterCriticalSection(This->lock);
+     LIST_FOR_EACH_ENTRY(rot_entry, &This->rot, const struct rot_entry, entry)
+     {
+         if ((rot_entry->moniker_data->ulCntData == moniker_data->ulCntData) &&
+@@ -655,7 +655,7 @@ RunningObjectTableImpl_GetTimeOfLastChange(IRunningObjectTable* iface,
+             break;
+         }
+     }
+-    LeaveCriticalSection(&This->lock);
++    LeaveCriticalSection(This->lock);
+ 
+     if (hr != S_OK)
+         hr = InternalIrotGetTimeOfLastChange(moniker_data, pfiletime);
+@@ -706,10 +706,20 @@ static const IRunningObjectTableVtbl VT_RunningObjectTableImpl =
+     RunningObjectTableImpl_EnumRunning
+ };
+ 
++static RTL_CRITICAL_SECTION IROT_lock;
++
++static RTL_CRITICAL_SECTION_DEBUG critsect_debug =
++{
++    0, 0, &IROT_lock,
++    { &critsect_debug.ProcessLocksList, &critsect_debug.ProcessLocksList },
++      0, 0, { (DWORD_PTR)(__FILE__ ": IROT_lock") }
++};
++static RTL_CRITICAL_SECTION IROT_lock = { &critsect_debug, -1, 0, 0, 0, 0 };
++
+ static RunningObjectTableImpl rot =
+ {
+     .IRunningObjectTable_iface.lpVtbl = &VT_RunningObjectTableImpl,
+-    .lock.LockCount = -1,
++    .lock = &IROT_lock,
+     .rot = LIST_INIT(rot.rot),
+ };
+ 
+@@ -741,13 +751,13 @@ void WINAPI DestroyRunningObjectTable(void)
+ 
+     TRACE("\n");
+ 
+-    EnterCriticalSection(&rot.lock);
++    EnterCriticalSection(rot.lock);
+     LIST_FOR_EACH_ENTRY_SAFE(rot_entry, cursor2, &rot.rot, struct rot_entry, entry)
+     {
+         list_remove(&rot_entry->entry);
+         rot_entry_delete(rot_entry);
+     }
+-    LeaveCriticalSection(&rot.lock);
++    LeaveCriticalSection(rot.lock);
+ }
+ 
+ static HRESULT get_moniker_for_progid_display_name(LPBC pbc,
+-- 
+2.40.1
+
+From b1b58f909f4cb2cf3c96d6e1920b52bc6cf9cd0a Mon Sep 17 00:00:00 2001
+From: llde <lorenzofersteam@live.it>
+Date: Tue, 23 May 2023 01:32:21 +0200
+Subject: [PATCH] unmarshal rot provided moniker outside the CS
+
+---
+ dlls/ole32/moniker.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/dlls/ole32/moniker.c b/dlls/ole32/moniker.c
+index f2668a1edbf..ac9a6f61ecc 100644
+--- a/dlls/ole32/moniker.c
++++ b/dlls/ole32/moniker.c
+@@ -541,13 +541,13 @@ RunningObjectTableImpl_GetObject( IRunningObjectTable* iface,
+         {
+             IStream *pStream;
+             hr = create_stream_on_mip_ro(rot_entry->object, &pStream);
++            LeaveCriticalSection(This->lock);
+             if (hr == S_OK)
+             {
+                 hr = CoUnmarshalInterface(pStream, &IID_IUnknown, (void **)ppunkObject);
+                 IStream_Release(pStream);
+             }
+ 
+-            LeaveCriticalSection(This->lock);
+             HeapFree(GetProcessHeap(), 0, moniker_data);
+ 
+             return hr;
+-- 
+2.40.1
+
+From 01e297aba3b56bb56f24308fe0817f72d1b8c0df Mon Sep 17 00:00:00 2001
+From: llde <lorenzofersteam@live.it>
+Date: Tue, 23 May 2023 00:07:04 +0200
+Subject: [PATCH] add implementation of PerfSetULongCounterValue and
+ PerfSetULongLongCounterValue (for VS)
+
+---
+ dlls/advapi32/advapi32.spec     |  4 +--
+ dlls/kernelbase/kernelbase.spec |  4 +--
+ dlls/kernelbase/main.c          | 57 +++++++++++++++++++++++++++++++++
+ 3 files changed, 61 insertions(+), 4 deletions(-)
+
+diff --git a/dlls/advapi32/advapi32.spec b/dlls/advapi32/advapi32.spec
+index b69186d07a7..26622f17137 100644
+--- a/dlls/advapi32/advapi32.spec
++++ b/dlls/advapi32/advapi32.spec
+@@ -577,8 +577,8 @@
+ # @ stub PerfRegSetValue
+ @ stdcall -import PerfSetCounterRefValue(long ptr long ptr)
+ @ stdcall -import PerfSetCounterSetInfo(long ptr long)
+-# @ stub PerfSetULongCounterValue
+-# @ stub PerfSetULongLongCounterValue
++@ stdcall -import PerfSetULongCounterValue(long ptr long long)
++@ stdcall -import PerfSetULongLongCounterValue(long ptr long int64)
+ @ stdcall -import PerfStartProvider(ptr ptr ptr)
+ @ stdcall -import PerfStartProviderEx(ptr ptr ptr)
+ @ stdcall -import PerfStopProvider(long)
+diff --git a/dlls/kernelbase/kernelbase.spec b/dlls/kernelbase/kernelbase.spec
+index cee3815460b..8b18a2bf09f 100644
+--- a/dlls/kernelbase/kernelbase.spec
++++ b/dlls/kernelbase/kernelbase.spec
+@@ -1189,8 +1189,8 @@
+ # @ stub PerfQueryInstance
+ @ stdcall PerfSetCounterRefValue(long ptr long ptr)
+ @ stdcall PerfSetCounterSetInfo(long ptr long)
+-# @ stub PerfSetULongCounterValue
+-# @ stub PerfSetULongLongCounterValue
++@ stdcall PerfSetULongCounterValue(long ptr long long)
++@ stdcall PerfSetULongLongCounterValue(long ptr long int64)
+ @ stdcall PerfStartProvider(ptr ptr ptr)
+ @ stdcall PerfStartProviderEx(ptr ptr ptr)
+ @ stdcall PerfStopProvider(long)
+diff --git a/dlls/kernelbase/main.c b/dlls/kernelbase/main.c
+index 0309ec91589..70a4107897b 100644
+--- a/dlls/kernelbase/main.c
++++ b/dlls/kernelbase/main.c
+@@ -338,6 +338,63 @@ ULONG WINAPI PerfSetCounterRefValue(HANDLE provider, PERF_COUNTERSET_INSTANCE *i
+     return STATUS_SUCCESS;
+ }
+ 
++/***********************************************************************
++ *           PerfSetULongCounterValue   (KERNELBASE.@)
++ */
++ULONG WINAPI PerfSetULongCounterValue(HANDLE provider, PERF_COUNTERSET_INSTANCE *instance,
++                                    ULONG counterid, ULONG value)
++{
++    struct perf_provider *prov = perf_provider_from_handle( provider );
++    struct counterset_template *template;
++    struct counterset_instance *inst;
++    unsigned int i;
++
++    FIXME( "provider %p, instance %p, counterid %lu, address %lu semi-stub.\n",
++           provider, instance, counterid, value );
++
++    if (!prov || !instance) return ERROR_INVALID_PARAMETER;
++
++    inst = CONTAINING_RECORD(instance, struct counterset_instance, instance);
++    template = inst->template;
++
++    for (i = 0; i < template->counterset.NumCounters; ++i)
++        if (template->counter[i].CounterId == counterid) break;
++
++    if (i == template->counterset.NumCounters) return ERROR_NOT_FOUND;
++    
++    *(ULONG*)((BYTE *)&inst->instance + sizeof(PERF_COUNTERSET_INSTANCE) + template->counter[i].Offset) = value;
++
++    return STATUS_SUCCESS;
++}
++/***********************************************************************
++ *           PerfSetULongLongCounterValue   (KERNELBASE.@)
++ */
++ULONG WINAPI PerfSetULongLongCounterValue(HANDLE provider, PERF_COUNTERSET_INSTANCE *instance,
++                                    ULONG counterid, ULONGLONG value)
++{
++    struct perf_provider *prov = perf_provider_from_handle( provider );
++    struct counterset_template *template;
++    struct counterset_instance *inst;
++    unsigned int i;
++
++    FIXME( "provider %p, instance %p, counterid %lu, address %lu semi-stub.\n",
++           provider, instance, counterid, value );
++
++    if (!prov || !instance) return ERROR_INVALID_PARAMETER;
++
++    inst = CONTAINING_RECORD(instance, struct counterset_instance, instance);
++    template = inst->template;
++
++    for (i = 0; i < template->counterset.NumCounters; ++i)
++        if (template->counter[i].CounterId == counterid) break;
++
++    if (i == template->counterset.NumCounters) return ERROR_NOT_FOUND;
++    
++    *(ULONGLONG*)((BYTE *)&inst->instance + sizeof(PERF_COUNTERSET_INSTANCE) + template->counter[i].Offset) = value;
++
++    return STATUS_SUCCESS;
++}
++
+ /***********************************************************************
+  *           PerfStartProvider   (KERNELBASE.@)
+  */
+-- 
+2.40.1
+
+From 4262294bbcb5fa4b5a02396794de475d09cbf873 Mon Sep 17 00:00:00 2001
+From: llde <lorenzofersteam@live.it>
+Date: Mon, 3 Jul 2023 00:52:34 +0200
+Subject: [PATCH] Partial implement SHAssocEnumHandlersForProtocolByApplication
+
+---
+ dlls/shell32/assoc.c      | 34 +++++++++++++++++++++++++++++++++-
+ dlls/shell32/shell32.spec |  1 +
+ 2 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/shell32/assoc.c b/dlls/shell32/assoc.c
+index 339be6ac445..f3d91857fb4 100644
+--- a/dlls/shell32/assoc.c
++++ b/dlls/shell32/assoc.c
+@@ -777,7 +777,7 @@ static HRESULT WINAPI IQueryAssociations_fnGetData(IQueryAssociations *iface,
+  * RETURNS
+  *  Success: S_OK.
+  *  Failure: An HRESULT error code indicating the error.
+- *
++ *filter
+  * NOTES
+  *  Presumably this function returns an enumerator object.
+  */
+@@ -1132,3 +1132,35 @@ HRESULT WINAPI SHAssocEnumHandlers(const WCHAR *extra, ASSOC_FILTER filter, IEnu
+     *enumhandlers = &enumassoc->IEnumAssocHandlers_iface;
+     return S_OK;
+ }
++
++
++
++/**************************************************************************
++ * SHAssocEnumHandlersForProtocolByApplication            [SHELL32.@]
++ */
++HRESULT WINAPI SHAssocEnumHandlersForProtocolByApplication(const WCHAR *protocol, REFIID riid, void **enumhandlers)
++{
++    struct enumassochandlers *enumassoc;
++
++    FIXME("(%s %d %p): stub\n", debugstr_w(protocol), debugstr_guid(riid), enumhandlers);
++    
++    if(!IsEqualIID(riid, &IID_IEnumAssocHandlers))
++    {
++        FIXME("Not implemented objects except IID_IEnumAssocHandlers\n");
++        return E_NOTIMPL;
++    }
++    
++    *enumhandlers = NULL;
++
++    enumassoc = SHAlloc(sizeof(*enumassoc));
++    if (!enumassoc)
++        return E_OUTOFMEMORY;
++
++    enumassoc->IEnumAssocHandlers_iface.lpVtbl = &enumassochandlersvtbl;
++    enumassoc->ref = 1;
++
++    *enumhandlers = &enumassoc->IEnumAssocHandlers_iface;
++    return S_OK;
++}
++
++
+diff --git a/dlls/shell32/shell32.spec b/dlls/shell32/shell32.spec
+index 2c969869722..fff0bb774eb 100644
+--- a/dlls/shell32/shell32.spec
++++ b/dlls/shell32/shell32.spec
+@@ -332,6 +332,7 @@
+ @ stdcall SHAddToRecentDocs (long ptr)
+ @ stdcall SHAppBarMessage(long ptr)
+ @ stdcall SHAssocEnumHandlers(wstr long ptr)
++@ stdcall SHAssocEnumHandlersForProtocolByApplication(wstr ptr ptr)
+ @ stdcall SHBindToFolderIDListParent(ptr ptr ptr ptr ptr)
+ @ stdcall SHBindToObject(ptr ptr ptr ptr ptr)
+ @ stdcall SHBindToParent(ptr ptr ptr ptr)
+-- 
+2.41.0
+
+From 6b62796eb5fb36e2fdbc90e6b2c1af527bfa56d8 Mon Sep 17 00:00:00 2001
+From: llde <lorenzofersteam@live.it>
+Date: Wed, 5 Jul 2023 12:53:13 +0200
+Subject: [PATCH] Return Success from QueryBlanket and SetBlanket functions
+
+---
+ dlls/combase/marshal.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/dlls/combase/marshal.c b/dlls/combase/marshal.c
+index 84f57b8c1c8..d188b83971c 100644
+--- a/dlls/combase/marshal.c
++++ b/dlls/combase/marshal.c
+@@ -1388,7 +1388,7 @@ static HRESULT WINAPI ProxyCliSec_QueryBlanket(IClientSecurity *iface,
+     if (pCapabilities)
+         *pCapabilities = EOAC_NONE;
+ 
+-    return E_NOTIMPL;
++    return S_OK;
+ }
+ 
+ static HRESULT WINAPI ProxyCliSec_SetBlanket(IClientSecurity *iface,
+@@ -1402,7 +1402,7 @@ static HRESULT WINAPI ProxyCliSec_SetBlanket(IClientSecurity *iface,
+     FIXME("%p, %ld, %ld, %s, %ld, %ld, %p, %#lx: stub\n", pProxy, AuthnSvc, AuthzSvc,
+           pServerPrincName == COLE_DEFAULT_PRINCIPAL ? "<default principal>" : debugstr_w(pServerPrincName),
+           AuthnLevel, ImpLevel, pAuthInfo, Capabilities);
+-    return E_NOTIMPL;
++    return S_OK;
+ }
+ 
+ static HRESULT WINAPI ProxyCliSec_CopyProxy(IClientSecurity *iface,
+-- 
+2.41.0
+
+From 39c64dabe5306326f4f93161f04fd0773987c630 Mon Sep 17 00:00:00 2001
+From: llde <lorenzofersteam@live.it>
+Date: Mon, 3 Jul 2023 23:34:17 +0200
+Subject: [PATCH] UrlMon: try stubbing function required by wininet
+
+---
+ dlls/urlmon/sec_mgr.c     |  4 +++-
+ dlls/urlmon/urlmon.spec   |  1 +
+ dlls/urlmon/urlmon_main.c | 10 ++++++++++
+ 3 files changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/dlls/urlmon/sec_mgr.c b/dlls/urlmon/sec_mgr.c
+index 82266066e0f..4afc160358f 100644
+--- a/dlls/urlmon/sec_mgr.c
++++ b/dlls/urlmon/sec_mgr.c
+@@ -1155,7 +1155,9 @@ static HRESULT WINAPI SecManagerImpl_ProcessUrlActionEx2(IInternetSecurityManage
+     SecManagerImpl *This = impl_from_IInternetSecurityManagerEx2(iface);
+     FIXME("(%p)->(%p %08lx %p %ld %p %ld %08lx %08Ix %p) stub\n", This, pUri, dwAction, pPolicy,
+           cbPolicy, pContext, cbContext, dwFlags, dwReserved, pdwOutFlags);
+-    return E_NOTIMPL;
++    if(!pUri || !pPolicy) return E_INVALIDARG;
++    *pPolicy =  URLPOLICY_ALLOW;
++    return S_OK;
+ }
+ 
+ static HRESULT WINAPI SecManagerImpl_GetSecurityIdEx2(IInternetSecurityManagerEx2 *iface,
+diff --git a/dlls/urlmon/urlmon.spec b/dlls/urlmon/urlmon.spec
+index 8725c8c5aeb..deb302e5179 100644
+--- a/dlls/urlmon/urlmon.spec
++++ b/dlls/urlmon/urlmon.spec
+@@ -108,6 +108,7 @@
+ 363 stdcall @(long long ptr) propsys.InitVariantFromResource
+ 387 stdcall @(ptr long) propsys.VariantToUInt32WithDefault
+ 410 stdcall @(long long) LogSqmBits
++414 stdcall @(long long) LogSqmIncrement
+ 423 stdcall @(long long long long) LogSqmUXCommandOffsetInternal
+ 444 stdcall @(long long long) MapUriToBrowserEmulationState
+ 445 stdcall -noname MapBrowserEmulationModeToUserAgent(ptr ptr)
+diff --git a/dlls/urlmon/urlmon_main.c b/dlls/urlmon/urlmon_main.c
+index 00ccc449e15..f3b93cf9cdc 100644
+--- a/dlls/urlmon/urlmon_main.c
++++ b/dlls/urlmon/urlmon_main.c
+@@ -841,3 +841,13 @@ HRESULT WINAPI GetIUriPriv(IUri *uri, void **p)
+     *p = NULL;
+     return E_NOTIMPL;
+ }
++
++/***********************************************************************
++ *            LogSqmIncrement
++ *    Undocumented
++ */
++DWORD WINAPI LogSqmIncrement(DWORD unknown1, DWORD unknown2 )
++{
++    FIXME("variable 1: %x; variable 2: %x: stub\n", unknown1, unknown2);
++    return 1;
++}
+-- 
+2.41.0
+

--- a/wine-tkg-git/VisualStudio2019_patches.mypatch
+++ b/wine-tkg-git/VisualStudio2019_patches.mypatch
@@ -299,7 +299,7 @@ index 0309ec91589..70a4107897b 100644
 +    struct counterset_instance *inst;
 +    unsigned int i;
 +
-+    FIXME( "provider %p, instance %p, counterid %lu, address %lu semi-stub.\n",
++    TRACE( "provider %p, instance %p, counterid %lu, address %lu semi-stub.\n",
 +           provider, instance, counterid, value );
 +
 +    if (!prov || !instance) return ERROR_INVALID_PARAMETER;
@@ -327,7 +327,7 @@ index 0309ec91589..70a4107897b 100644
 +    struct counterset_instance *inst;
 +    unsigned int i;
 +
-+    FIXME( "provider %p, instance %p, counterid %lu, address %lu semi-stub.\n",
++    TRACE( "provider %p, instance %p, counterid %lu, address %lu semi-stub.\n",
 +           provider, instance, counterid, value );
 +
 +    if (!prov || !instance) return ERROR_INVALID_PARAMETER;

--- a/wine-tkg-git/atiadlxx.mypatch
+++ b/wine-tkg-git/atiadlxx.mypatch
@@ -1,0 +1,1843 @@
+From fb15479455380deaac564e47613dcfd60c703693 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?R=C3=A9mi=20Bernon?= <rbernon@codeweavers.com>
+Date: Fri, 10 Jul 2020 10:09:21 +0200
+Subject: [PATCH] HACK: atiadlxx: Add stub DLL, disabled by default.
+
+This is required by several Call of Duty games when using AMD GPU.
+---
+ configure                     |    2 +
+ configure.ac                  |    1 +
+ dlls/atiadlxx/Makefile.in     |    5 +
+ dlls/atiadlxx/atiadlxx.spec   | 1138 +++++++++++++++++++++++++++++++++
+ dlls/atiadlxx/atiadlxx_main.c |   93 +++
+ loader/wine.inf.in            |    2 +
+ 6 files changed, 1241 insertions(+)
+ create mode 100644 dlls/atiadlxx/Makefile.in
+ create mode 100644 dlls/atiadlxx/atiadlxx.spec
+ create mode 100644 dlls/atiadlxx/atiadlxx_main.c
+
+diff --git a/configure b/configure
+index b6d84f93272..7a425d08eab 100755
+--- a/configure
++++ b/configure
+@@ -1141,6 +1141,7 @@ enable_api_ms_win_shell_shellcom_l1_1_0
+ enable_api_ms_win_shell_shellfolders_l1_1_0
+ enable_apphelp
+ enable_appwiz_cpl
++enable_atiadlxx
+ enable_atl
+ enable_atl100
+ enable_atl110
+@@ -20547,6 +20548,7 @@ wine_fn_config_makefile dlls/api-ms-win-shell-shellfolders-l1-1-0 enable_api_ms_
+ wine_fn_config_makefile dlls/apphelp enable_apphelp
+ wine_fn_config_makefile dlls/apphelp/tests enable_tests
+ wine_fn_config_makefile dlls/appwiz.cpl enable_appwiz_cpl
++wine_fn_config_makefile dlls/atiadlxx enable_atiadlxx
+ wine_fn_config_makefile dlls/atl enable_atl
+ wine_fn_config_makefile dlls/atl/tests enable_tests
+ wine_fn_config_makefile dlls/atl100 enable_atl100
+diff --git a/configure.ac b/configure.ac
+index c4f6d2975b3..1733a63b034 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3076,6 +3076,7 @@ WINE_CONFIG_MAKEFILE(dlls/api-ms-win-shell-shellfolders-l1-1-0)
+ WINE_CONFIG_MAKEFILE(dlls/apphelp)
+ WINE_CONFIG_MAKEFILE(dlls/apphelp/tests)
+ WINE_CONFIG_MAKEFILE(dlls/appwiz.cpl)
++WINE_CONFIG_MAKEFILE(dlls/atiadlxx)
+ WINE_CONFIG_MAKEFILE(dlls/atl)
+ WINE_CONFIG_MAKEFILE(dlls/atl/tests)
+ WINE_CONFIG_MAKEFILE(dlls/atl100)
+diff --git a/dlls/atiadlxx/Makefile.in b/dlls/atiadlxx/Makefile.in
+new file mode 100644
+index 00000000000..78af7168c20
+--- /dev/null
++++ b/dlls/atiadlxx/Makefile.in
+@@ -0,0 +1,5 @@
++MODULE = atiadlxx.dll
++EXTRADLLFLAGS = -mno-cygwin -Wb,--prefer-native
++
++C_SRCS = \
++	atiadlxx_main.c
+diff --git a/dlls/atiadlxx/atiadlxx.spec b/dlls/atiadlxx/atiadlxx.spec
+new file mode 100644
+index 00000000000..e2a1f46a838
+--- /dev/null
++++ b/dlls/atiadlxx/atiadlxx.spec
+@@ -0,0 +1,1138 @@
++@ stub ADL2_ADC_CurrentProfileFromDrv_Get
++@ stub ADL2_ADC_Display_AdapterDeviceProfileEx_Get
++@ stub ADL2_ADC_DrvDataToProfile_Copy
++@ stub ADL2_ADC_FindClosestMode_Get
++@ stub ADL2_ADC_IsDevModeEqual_Get
++@ stub ADL2_ADC_Profile_Apply
++@ stub ADL2_APO_AudioDelayAdjustmentInfo_Get
++@ stub ADL2_APO_AudioDelay_Restore
++@ stub ADL2_APO_AudioDelay_Set
++@ stub ADL2_AdapterLimitation_Caps
++@ stub ADL2_AdapterX2_Caps
++@ stub ADL2_Adapter_AMDAndNonAMDDIsplayClone_Get
++@ stub ADL2_Adapter_ASICFamilyType_Get
++@ stub ADL2_Adapter_ASICInfo_Get
++@ stub ADL2_Adapter_Accessibility_Get
++@ stub ADL2_Adapter_AceDefaults_Restore
++@ stub ADL2_Adapter_Active_Get
++@ stub ADL2_Adapter_Active_Set
++@ stub ADL2_Adapter_Active_SetPrefer
++@ stub ADL2_Adapter_AdapterInfoX2_Get
++@ stub ADL2_Adapter_AdapterInfoX3_Get
++@ stub ADL2_Adapter_AdapterInfoX4_Get
++@ stub ADL2_Adapter_AdapterInfo_Get
++@ stub ADL2_Adapter_AdapterList_Disable
++@ stub ADL2_Adapter_AdapterLocationPath_Get
++@ stub ADL2_Adapter_Aspects_Get
++@ stub ADL2_Adapter_AudioChannelSplitConfiguration_Get
++@ stub ADL2_Adapter_AudioChannelSplit_Disable
++@ stub ADL2_Adapter_AudioChannelSplit_Enable
++@ stub ADL2_Adapter_BigSw_Info_Get
++@ stub ADL2_Adapter_BlackAndWhiteLevelSupport_Get
++@ stub ADL2_Adapter_BlackAndWhiteLevel_Get
++@ stub ADL2_Adapter_BlackAndWhiteLevel_Set
++@ stub ADL2_Adapter_BoardLayout_Get
++@ stub ADL2_Adapter_Caps
++@ stub ADL2_Adapter_ChipSetInfo_Get
++@ stub ADL2_Adapter_CloneTypes_Get
++@ stub ADL2_Adapter_ConfigMemory_Cap
++@ stub ADL2_Adapter_ConfigMemory_Get
++@ stub ADL2_Adapter_ConfigureState_Get
++@ stub ADL2_Adapter_ConnectionData_Get
++@ stub ADL2_Adapter_ConnectionData_Remove
++@ stub ADL2_Adapter_ConnectionData_Set
++@ stub ADL2_Adapter_ConnectionState_Get
++@ stub ADL2_Adapter_CrossDisplayPlatformInfo_Get
++@ stub ADL2_Adapter_CrossGPUClone_Disable
++@ stub ADL2_Adapter_CrossdisplayAdapterRole_Caps
++@ stub ADL2_Adapter_CrossdisplayInfoX2_Set
++@ stub ADL2_Adapter_CrossdisplayInfo_Get
++@ stub ADL2_Adapter_CrossdisplayInfo_Set
++@ stub ADL2_Adapter_CrossfireX2_Get
++@ stub ADL2_Adapter_Crossfire_Caps
++@ stub ADL2_Adapter_Crossfire_Get
++@ stub ADL2_Adapter_Crossfire_Set
++@ stub ADL2_Adapter_DefaultAudioChannelTable_Load
++@ stub ADL2_Adapter_Desktop_Caps
++@ stub ADL2_Adapter_Desktop_SupportedSLSGridTypes_Get
++@ stub ADL2_Adapter_DeviceID_Get
++@ stub ADL2_Adapter_DisplayAudioEndpoint_Enable
++@ stub ADL2_Adapter_DisplayAudioEndpoint_Mute
++@ stub ADL2_Adapter_DisplayAudioInfo_Get
++@ stub ADL2_Adapter_DisplayGTCCaps_Get
++@ stub ADL2_Adapter_Display_Caps
++@ stub ADL2_Adapter_DriverSettings_Get
++@ stub ADL2_Adapter_DriverSettings_Set
++@ stub ADL2_Adapter_ECC_ErrorInjection_Set
++@ stub ADL2_Adapter_ECC_ErrorRecords_Get
++@ stub ADL2_Adapter_EDC_ErrorInjection_Set
++@ stub ADL2_Adapter_EDC_ErrorRecords_Get
++@ stub ADL2_Adapter_EDIDManagement_Caps
++@ stub ADL2_Adapter_EmulationMode_Set
++@ stub ADL2_Adapter_ExtInfo_Get
++@ stub ADL2_Adapter_Feature_Caps
++@ stub ADL2_Adapter_FrameMetrics_Caps
++@ stub ADL2_Adapter_FrameMetrics_FrameDuration_Disable
++@ stub ADL2_Adapter_FrameMetrics_FrameDuration_Enable
++@ stub ADL2_Adapter_FrameMetrics_FrameDuration_Get
++@ stub ADL2_Adapter_FrameMetrics_FrameDuration_Start
++@ stub ADL2_Adapter_FrameMetrics_FrameDuration_Stop
++@ stub ADL2_Adapter_FrameMetrics_Get
++@ stub ADL2_Adapter_FrameMetrics_Start
++@ stub ADL2_Adapter_FrameMetrics_Stop
++@ stub ADL2_Adapter_Gamma_Get
++@ stub ADL2_Adapter_Gamma_Set
++@ stub ADL2_Adapter_Graphic_Core_Info_Get
++@ stub ADL2_Adapter_HBC_Caps
++@ stub ADL2_Adapter_HBM_ECC_UC_Check
++@ stub ADL2_Adapter_Headless_Get
++@ stub ADL2_Adapter_ID_Get
++@ stub ADL2_Adapter_IsGamingDriver_Info_Get
++@ stub ADL2_Adapter_LocalDisplayConfig_Get
++@ stub ADL2_Adapter_LocalDisplayConfig_Set
++@ stub ADL2_Adapter_LocalDisplayState_Get
++@ stub ADL2_Adapter_MVPU_Set
++@ stub ADL2_Adapter_MaxCursorSize_Get
++@ stub ADL2_Adapter_MemoryInfo2_Get
++@ stub ADL2_Adapter_MemoryInfo_Get
++@ stub ADL2_Adapter_MirabilisSupport_Get
++@ stub ADL2_Adapter_ModeSwitch
++@ stub ADL2_Adapter_ModeTimingOverride_Caps
++@ stub ADL2_Adapter_Modes_ReEnumerate
++@ stub ADL2_Adapter_NumberOfActivatableSources_Get
++@ stdcall ADL2_Adapter_NumberOfAdapters_Get(ptr ptr)
++@ stub ADL2_Adapter_ObservedClockInfo_Get
++@ stub ADL2_Adapter_PMLog_Start
++@ stub ADL2_Adapter_PMLog_Stop
++@ stub ADL2_Adapter_PMLog_Support_Get
++@ stub ADL2_Adapter_PreFlipPostProcessing_Disable
++@ stub ADL2_Adapter_PreFlipPostProcessing_Enable
++@ stub ADL2_Adapter_PreFlipPostProcessing_Get_Status
++@ stub ADL2_Adapter_PreFlipPostProcessing_Select_LUT_Algorithm
++@ stub ADL2_Adapter_PreFlipPostProcessing_Select_LUT_Buffer
++@ stub ADL2_Adapter_PreFlipPostProcessing_Unselect_LUT_Buffer
++@ stub ADL2_Adapter_Primary_Get
++@ stub ADL2_Adapter_Primary_Set
++@ stub ADL2_Adapter_RAS_ErrorInjection_Set
++@ stub ADL2_Adapter_RegValueInt_Get
++@ stub ADL2_Adapter_RegValueInt_Set
++@ stub ADL2_Adapter_RegValueString_Get
++@ stub ADL2_Adapter_RegValueString_Set
++@ stub ADL2_Adapter_SWInfo_Get
++@ stub ADL2_Adapter_Speed_Caps
++@ stub ADL2_Adapter_Speed_Get
++@ stub ADL2_Adapter_Speed_Set
++@ stub ADL2_Adapter_SupportedConnections_Get
++@ stub ADL2_Adapter_TRNG_Get
++@ stub ADL2_Adapter_Tear_Free_Cap
++@ stub ADL2_Adapter_VRAMUsage_Get
++@ stub ADL2_Adapter_VariBrightEnable_Set
++@ stub ADL2_Adapter_VariBrightLevel_Get
++@ stub ADL2_Adapter_VariBrightLevel_Set
++@ stub ADL2_Adapter_VariBright_Caps
++@ stub ADL2_Adapter_VerndorID_Int_get
++@ stub ADL2_Adapter_VideoBiosInfo_Get
++@ stub ADL2_Adapter_VideoTheaterModeInfo_Get
++@ stub ADL2_Adapter_VideoTheaterModeInfo_Set
++@ stub ADL2_Adapter_XConnectSupport_Get
++@ stub ADL2_ApplicationProfilesX2_AppInterceptionList_Set
++@ stub ADL2_ApplicationProfilesX2_AppStartStopInfo_Get
++@ stub ADL2_ApplicationProfiles_AppInterceptionList_Set
++@ stub ADL2_ApplicationProfiles_AppInterception_Set
++@ stub ADL2_ApplicationProfiles_AppStartStopInfo_Get
++@ stub ADL2_ApplicationProfiles_AppStartStop_Resume
++@ stub ADL2_ApplicationProfiles_Applications_Get
++@ stub ADL2_ApplicationProfiles_ConvertToCompact
++@ stub ADL2_ApplicationProfiles_DriverAreaPrivacy_Get
++@ stub ADL2_ApplicationProfiles_GetCustomization
++@ stub ADL2_ApplicationProfiles_HitListsX2_Get
++@ stub ADL2_ApplicationProfiles_HitListsX3_Get
++@ stub ADL2_ApplicationProfiles_HitLists_Get
++@ stub ADL2_ApplicationProfiles_ProfileApplicationX2_Assign
++@ stub ADL2_ApplicationProfiles_ProfileApplication_Assign
++@ stub ADL2_ApplicationProfiles_ProfileOfAnApplicationX2_Search
++@ stub ADL2_ApplicationProfiles_ProfileOfAnApplication_InMemorySearch
++@ stub ADL2_ApplicationProfiles_ProfileOfAnApplication_Search
++@ stub ADL2_ApplicationProfiles_Profile_Create
++@ stub ADL2_ApplicationProfiles_Profile_Exist
++@ stub ADL2_ApplicationProfiles_Profile_Remove
++@ stub ADL2_ApplicationProfiles_PropertyType_Get
++@ stub ADL2_ApplicationProfiles_Release_Get
++@ stub ADL2_ApplicationProfiles_RemoveApplication
++@ stub ADL2_ApplicationProfiles_StatusInfo_Get
++@ stub ADL2_ApplicationProfiles_System_Reload
++@ stub ADL2_ApplicationProfiles_User_Load
++@ stub ADL2_ApplicationProfiles_User_Unload
++@ stub ADL2_Audio_CurrentSampleRate_Get
++@ stub ADL2_AutoTuningResult_Get
++@ stub ADL2_BOOST_Settings_Get
++@ stub ADL2_BOOST_Settings_Set
++@ stub ADL2_Blockchain_BlockchainMode_Caps
++@ stub ADL2_Blockchain_BlockchainMode_Get
++@ stub ADL2_Blockchain_BlockchainMode_Set
++@ stub ADL2_Blockchain_Hashrate_Set
++@ stub ADL2_CDS_UnsafeMode_Set
++@ stub ADL2_CHILL_SettingsX2_Get
++@ stub ADL2_CHILL_SettingsX2_Set
++@ stub ADL2_CV_DongleSettings_Get
++@ stub ADL2_CV_DongleSettings_Reset
++@ stub ADL2_CV_DongleSettings_Set
++@ stub ADL2_Chill_Caps_Get
++@ stub ADL2_Chill_Settings_Get
++@ stub ADL2_Chill_Settings_Notify
++@ stub ADL2_Chill_Settings_Set
++@ stub ADL2_CustomFan_Caps
++@ stub ADL2_CustomFan_Get
++@ stub ADL2_CustomFan_Set
++@ stub ADL2_DELAG_Settings_Get
++@ stub ADL2_DELAG_Settings_Set
++@ stub ADL2_DFP_AllowOnlyCETimings_Get
++@ stub ADL2_DFP_AllowOnlyCETimings_Set
++@ stub ADL2_DFP_BaseAudioSupport_Get
++@ stub ADL2_DFP_GPUScalingEnable_Get
++@ stub ADL2_DFP_GPUScalingEnable_Set
++@ stub ADL2_DFP_HDMISupport_Get
++@ stub ADL2_DFP_MVPUAnalogSupport_Get
++@ stub ADL2_DFP_PixelFormat_Caps
++@ stub ADL2_DFP_PixelFormat_Get
++@ stub ADL2_DFP_PixelFormat_Set
++@ stub ADL2_DVRSupport_Get
++@ stub ADL2_Desktop_DOPP_Enable
++@ stub ADL2_Desktop_DOPP_EnableX2
++@ stub ADL2_Desktop_Detach
++@ stub ADL2_Desktop_Device_Create
++@ stub ADL2_Desktop_Device_Destroy
++@ stub ADL2_Desktop_ExclusiveModeX2_Get
++@ stub ADL2_Desktop_HardwareCursor_SetBitmap
++@ stub ADL2_Desktop_HardwareCursor_SetPosition
++@ stub ADL2_Desktop_HardwareCursor_Toggle
++@ stub ADL2_Desktop_PFPAComplete_Set
++@ stub ADL2_Desktop_PFPAState_Get
++@ stub ADL2_Desktop_PrimaryInfo_Get
++@ stub ADL2_Desktop_TextureState_Get
++@ stub ADL2_Desktop_Texture_Enable
++@ stub ADL2_Device_PMLog_Device_Create
++@ stub ADL2_Device_PMLog_Device_Destroy
++@ stub ADL2_DisplayScaling_Set
++@ stub ADL2_Display_AdapterID_Get
++@ stub ADL2_Display_AdjustCaps_Get
++@ stub ADL2_Display_AdjustmentCoherent_Get
++@ stub ADL2_Display_AdjustmentCoherent_Set
++@ stub ADL2_Display_AudioMappingInfo_Get
++@ stub ADL2_Display_AvivoColor_Get
++@ stub ADL2_Display_AvivoCurrentColor_Set
++@ stub ADL2_Display_AvivoDefaultColor_Set
++@ stub ADL2_Display_BackLight_Get
++@ stub ADL2_Display_BackLight_Set
++@ stub ADL2_Display_BezelOffsetSteppingSize_Get
++@ stub ADL2_Display_BezelOffset_Set
++@ stub ADL2_Display_BezelSupported_Validate
++@ stub ADL2_Display_Capabilities_Get
++@ stub ADL2_Display_ColorCaps_Get
++@ stub ADL2_Display_ColorDepth_Get
++@ stub ADL2_Display_ColorDepth_Set
++@ stub ADL2_Display_ColorTemperatureSourceDefault_Get
++@ stub ADL2_Display_ColorTemperatureSource_Get
++@ stub ADL2_Display_ColorTemperatureSource_Set
++@ stub ADL2_Display_Color_Get
++@ stub ADL2_Display_Color_Set
++@ stub ADL2_Display_ConnectedDisplays_Get
++@ stub ADL2_Display_ContainerID_Get
++@ stub ADL2_Display_ControllerOverlayAdjustmentCaps_Get
++@ stub ADL2_Display_ControllerOverlayAdjustmentData_Get
++@ stub ADL2_Display_ControllerOverlayAdjustmentData_Set
++@ stub ADL2_Display_CustomizedModeListNum_Get
++@ stub ADL2_Display_CustomizedModeList_Get
++@ stub ADL2_Display_CustomizedMode_Add
++@ stub ADL2_Display_CustomizedMode_Delete
++@ stub ADL2_Display_CustomizedMode_Validate
++@ stub ADL2_Display_DCE_Get
++@ stub ADL2_Display_DCE_Set
++@ stub ADL2_Display_DDCBlockAccess_Get
++@ stub ADL2_Display_DDCInfo2_Get
++@ stub ADL2_Display_DDCInfo_Get
++@ stub ADL2_Display_Deflicker_Get
++@ stub ADL2_Display_Deflicker_Set
++@ stub ADL2_Display_DeviceConfig_Get
++@ stub ADL2_Display_DisplayContent_Cap
++@ stub ADL2_Display_DisplayContent_Get
++@ stub ADL2_Display_DisplayContent_Set
++@ stub ADL2_Display_DisplayInfo_Get
++@ stub ADL2_Display_DisplayMapConfigX2_Set
++@ stub ADL2_Display_DisplayMapConfig_Get
++@ stub ADL2_Display_DisplayMapConfig_PossibleAddAndRemove
++@ stub ADL2_Display_DisplayMapConfig_Set
++@ stub ADL2_Display_DisplayMapConfig_Validate
++@ stub ADL2_Display_DitherState_Get
++@ stub ADL2_Display_DitherState_Set
++@ stub ADL2_Display_Downscaling_Caps
++@ stub ADL2_Display_DpMstAuxMsg_Get
++@ stub ADL2_Display_DpMstInfo_Get
++@ stub ADL2_Display_DummyVirtual_Destroy
++@ stub ADL2_Display_DummyVirtual_Get
++@ stub ADL2_Display_EdidData_Get
++@ stub ADL2_Display_EdidData_Set
++@ stub ADL2_Display_EnumDisplays_Get
++@ stub ADL2_Display_FilterSVideo_Get
++@ stub ADL2_Display_FilterSVideo_Set
++@ stub ADL2_Display_ForcibleDisplay_Get
++@ stub ADL2_Display_ForcibleDisplay_Set
++@ stub ADL2_Display_FormatsOverride_Get
++@ stub ADL2_Display_FormatsOverride_Set
++@ stub ADL2_Display_FreeSyncState_Get
++@ stub ADL2_Display_FreeSyncState_Set
++@ stub ADL2_Display_FreeSync_Cap
++@ stub ADL2_Display_GamutMapping_Get
++@ stub ADL2_Display_GamutMapping_Reset
++@ stub ADL2_Display_GamutMapping_Set
++@ stub ADL2_Display_Gamut_Caps
++@ stub ADL2_Display_Gamut_Get
++@ stub ADL2_Display_Gamut_Set
++@ stub ADL2_Display_HDCP_Get
++@ stub ADL2_Display_HDCP_Set
++@ stub ADL2_Display_HDRState_Get
++@ stub ADL2_Display_HDRState_Set
++@ stub ADL2_Display_ImageExpansion_Get
++@ stub ADL2_Display_ImageExpansion_Set
++@ stub ADL2_Display_InfoPacket_Get
++@ stub ADL2_Display_InfoPacket_Set
++@ stub ADL2_Display_IsVirtual_Get
++@ stub ADL2_Display_LCDRefreshRateCapability_Get
++@ stub ADL2_Display_LCDRefreshRateOptions_Get
++@ stub ADL2_Display_LCDRefreshRateOptions_Set
++@ stub ADL2_Display_LCDRefreshRate_Get
++@ stub ADL2_Display_LCDRefreshRate_Set
++@ stub ADL2_Display_Limits_Get
++@ stub ADL2_Display_MVPUCaps_Get
++@ stub ADL2_Display_MVPUStatus_Get
++@ stub ADL2_Display_ModeTimingOverrideInfo_Get
++@ stub ADL2_Display_ModeTimingOverrideListX2_Get
++@ stub ADL2_Display_ModeTimingOverrideListX3_Get
++@ stub ADL2_Display_ModeTimingOverrideList_Get
++@ stub ADL2_Display_ModeTimingOverrideX2_Get
++@ stub ADL2_Display_ModeTimingOverrideX2_Set
++@ stub ADL2_Display_ModeTimingOverrideX3_Get
++@ stub ADL2_Display_ModeTimingOverride_Delete
++@ stub ADL2_Display_ModeTimingOverride_Get
++@ stub ADL2_Display_ModeTimingOverride_Set
++@ stub ADL2_Display_Modes_Get
++@ stub ADL2_Display_Modes_Set
++@ stub ADL2_Display_Modes_X2_Get
++@ stub ADL2_Display_MonitorPowerState_Set
++@ stub ADL2_Display_NativeAUXChannel_Access
++@ stub ADL2_Display_NeedWorkaroundFor5Clone_Get
++@ stub ADL2_Display_NumberOfDisplays_Get
++@ stub ADL2_Display_ODClockConfig_Set
++@ stub ADL2_Display_ODClockInfo_Get
++@ stub ADL2_Display_Overlap_NotifyAdjustment
++@ stub ADL2_Display_Overlap_Set
++@ stub ADL2_Display_Overscan_Get
++@ stub ADL2_Display_Overscan_Set
++@ stub ADL2_Display_PixelFormatDefault_Get
++@ stub ADL2_Display_PixelFormat_Get
++@ stub ADL2_Display_PixelFormat_Set
++@ stub ADL2_Display_Position_Get
++@ stub ADL2_Display_Position_Set
++@ stub ADL2_Display_PossibleMapping_Get
++@ stub ADL2_Display_PossibleMode_Get
++@ stub ADL2_Display_PowerXpressActiveGPU_Get
++@ stub ADL2_Display_PowerXpressActiveGPU_Set
++@ stub ADL2_Display_PowerXpressActvieGPUR2_Get
++@ stub ADL2_Display_PowerXpressVersion_Get
++@ stub ADL2_Display_PowerXpress_AutoSwitchConfig_Get
++@ stub ADL2_Display_PowerXpress_AutoSwitchConfig_Set
++@ stub ADL2_Display_PreferredMode_Get
++@ stub ADL2_Display_PreservedAspectRatio_Get
++@ stub ADL2_Display_PreservedAspectRatio_Set
++@ stub ADL2_Display_Property_Get
++@ stub ADL2_Display_Property_Set
++@ stub ADL2_Display_RcDisplayAdjustment
++@ stub ADL2_Display_ReGammaCoefficients_Get
++@ stub ADL2_Display_ReGammaCoefficients_Set
++@ stub ADL2_Display_ReducedBlanking_Get
++@ stub ADL2_Display_ReducedBlanking_Set
++@ stub ADL2_Display_RegammaR1_Get
++@ stub ADL2_Display_RegammaR1_Set
++@ stub ADL2_Display_Regamma_Get
++@ stub ADL2_Display_Regamma_Set
++@ stub ADL2_Display_SLSBuilder_CommonMode_Get
++@ stub ADL2_Display_SLSBuilder_Create
++@ stub ADL2_Display_SLSBuilder_DisplaysCanBeNextCandidateInSLS_Get
++@ stub ADL2_Display_SLSBuilder_DisplaysCanBeNextCandidateToEnabled_Get
++@ stub ADL2_Display_SLSBuilder_Get
++@ stub ADL2_Display_SLSBuilder_IsActive_Notify
++@ stub ADL2_Display_SLSBuilder_MaxSLSLayoutSize_Get
++@ stub ADL2_Display_SLSBuilder_TimeOut_Get
++@ stub ADL2_Display_SLSBuilder_Update
++@ stub ADL2_Display_SLSGrid_Caps
++@ stub ADL2_Display_SLSMapConfigX2_Delete
++@ stub ADL2_Display_SLSMapConfigX2_Get
++@ stub ADL2_Display_SLSMapConfig_Create
++@ stub ADL2_Display_SLSMapConfig_Delete
++@ stub ADL2_Display_SLSMapConfig_Get
++@ stub ADL2_Display_SLSMapConfig_ImageCropType_Set
++@ stub ADL2_Display_SLSMapConfig_Rearrange
++@ stub ADL2_Display_SLSMapConfig_SetState
++@ stub ADL2_Display_SLSMapConfig_SupportedImageCropType_Get
++@ stub ADL2_Display_SLSMapConfig_Valid
++@ stub ADL2_Display_SLSMapIndexList_Get
++@ stub ADL2_Display_SLSMapIndex_Get
++@ stub ADL2_Display_SLSMiddleMode_Get
++@ stub ADL2_Display_SLSMiddleMode_Set
++@ stub ADL2_Display_SLSRecords_Get
++@ stub ADL2_Display_Sharpness_Caps
++@ stub ADL2_Display_Sharpness_Get
++@ stub ADL2_Display_Sharpness_Info_Get
++@ stub ADL2_Display_Sharpness_Set
++@ stub ADL2_Display_Size_Get
++@ stub ADL2_Display_Size_Set
++@ stub ADL2_Display_SourceContentAttribute_Get
++@ stub ADL2_Display_SourceContentAttribute_Set
++@ stub ADL2_Display_SplitDisplay_Caps
++@ stub ADL2_Display_SplitDisplay_Get
++@ stub ADL2_Display_SplitDisplay_RestoreDesktopConfiguration
++@ stub ADL2_Display_SplitDisplay_Set
++@ stub ADL2_Display_SupportedColorDepth_Get
++@ stub ADL2_Display_SupportedPixelFormat_Get
++@ stub ADL2_Display_SwitchingCapability_Get
++@ stub ADL2_Display_TVCaps_Get
++@ stub ADL2_Display_TargetTimingX2_Get
++@ stub ADL2_Display_TargetTiming_Get
++@ stub ADL2_Display_UnderScan_Auto_Get
++@ stub ADL2_Display_UnderScan_Auto_Set
++@ stub ADL2_Display_UnderscanState_Get
++@ stub ADL2_Display_UnderscanState_Set
++@ stub ADL2_Display_UnderscanSupport_Get
++@ stub ADL2_Display_Underscan_Get
++@ stub ADL2_Display_Underscan_Set
++@ stub ADL2_Display_Vector_Get
++@ stub ADL2_Display_ViewPort_Cap
++@ stub ADL2_Display_ViewPort_Get
++@ stub ADL2_Display_ViewPort_Set
++@ stub ADL2_Display_VirtualType_Get
++@ stub ADL2_Display_WriteAndReadI2C
++@ stub ADL2_Display_WriteAndReadI2CLargePayload
++@ stub ADL2_Display_WriteAndReadI2CRev_Get
++@ stub ADL2_ElmCompatibilityMode_Caps
++@ stub ADL2_ElmCompatibilityMode_Status_Get
++@ stub ADL2_ElmCompatibilityMode_Status_Set
++@ stub ADL2_ExclusiveModeGet
++@ stub ADL2_FPS_Caps
++@ stub ADL2_FPS_Settings_Get
++@ stub ADL2_FPS_Settings_Reset
++@ stub ADL2_FPS_Settings_Set
++@ stub ADL2_Feature_Settings_Get
++@ stub ADL2_Feature_Settings_Set
++@ stub ADL2_Flush_Driver_Data
++@ stub ADL2_GPUVMPageSize_Info_Get
++@ stub ADL2_GPUVMPageSize_Info_Set
++@ stub ADL2_GPUVerInfo_Get
++@ stub ADL2_GcnAsicInfo_Get
++@ stub ADL2_Graphics_IsDetachableGraphicsPlatform_Get
++@ stub ADL2_Graphics_IsGfx9AndAbove
++@ stub ADL2_Graphics_MantleVersion_Get
++@ stub ADL2_Graphics_Platform_Get
++@ stdcall ADL2_Graphics_VersionsX2_Get(ptr ptr)
++@ stub ADL2_Graphics_Versions_Get
++@ stub ADL2_Graphics_VulkanVersion_Get
++@ stub ADL2_HybridGraphicsGPU_Set
++@ stub ADL2_MGPUSLS_Status_Set
++@ stub ADL2_MMD_FeatureList_Get
++@ stub ADL2_MMD_FeatureValuesX2_Get
++@ stub ADL2_MMD_FeatureValuesX2_Set
++@ stub ADL2_MMD_FeatureValues_Get
++@ stub ADL2_MMD_FeatureValues_Set
++@ stub ADL2_MMD_FeaturesX2_Caps
++@ stub ADL2_MMD_Features_Caps
++@ stub ADL2_MMD_VideoAdjustInfo_Get
++@ stub ADL2_MMD_VideoAdjustInfo_Set
++@ stub ADL2_MMD_VideoColor_Caps
++@ stub ADL2_MMD_VideoColor_Get
++@ stub ADL2_MMD_VideoColor_Set
++@ stub ADL2_MMD_Video_Caps
++@ stub ADL2_Main_ControlX2_Create
++@ stdcall ADL2_Main_Control_Create(ptr long ptr)
++@ stub ADL2_Main_Control_Destroy
++@ stub ADL2_Main_Control_GetProcAddress
++@ stub ADL2_Main_Control_IsFunctionValid
++@ stub ADL2_Main_Control_Refresh
++@ stub ADL2_Main_LogDebug_Set
++@ stub ADL2_Main_LogError_Set
++@ stub ADL2_New_QueryPMLogData_Get
++@ stub ADL2_Overdrive5_CurrentActivity_Get
++@ stub ADL2_Overdrive5_FanSpeedInfo_Get
++@ stub ADL2_Overdrive5_FanSpeedToDefault_Set
++@ stub ADL2_Overdrive5_FanSpeed_Get
++@ stub ADL2_Overdrive5_FanSpeed_Set
++@ stub ADL2_Overdrive5_ODParameters_Get
++@ stub ADL2_Overdrive5_ODPerformanceLevels_Get
++@ stub ADL2_Overdrive5_ODPerformanceLevels_Set
++@ stub ADL2_Overdrive5_PowerControlAbsValue_Caps
++@ stub ADL2_Overdrive5_PowerControlAbsValue_Get
++@ stub ADL2_Overdrive5_PowerControlAbsValue_Set
++@ stub ADL2_Overdrive5_PowerControlInfo_Get
++@ stub ADL2_Overdrive5_PowerControl_Caps
++@ stub ADL2_Overdrive5_PowerControl_Get
++@ stub ADL2_Overdrive5_PowerControl_Set
++@ stub ADL2_Overdrive5_Temperature_Get
++@ stub ADL2_Overdrive5_ThermalDevices_Enum
++@ stub ADL2_Overdrive6_AdvancedFan_Caps
++@ stub ADL2_Overdrive6_CapabilitiesEx_Get
++@ stub ADL2_Overdrive6_Capabilities_Get
++@ stub ADL2_Overdrive6_ControlI2C
++@ stub ADL2_Overdrive6_CurrentPower_Get
++@ stub ADL2_Overdrive6_CurrentStatus_Get
++@ stub ADL2_Overdrive6_FanPWMLimitData_Get
++@ stub ADL2_Overdrive6_FanPWMLimitData_Set
++@ stub ADL2_Overdrive6_FanPWMLimitRangeInfo_Get
++@ stub ADL2_Overdrive6_FanSpeed_Get
++@ stub ADL2_Overdrive6_FanSpeed_Reset
++@ stub ADL2_Overdrive6_FanSpeed_Set
++@ stub ADL2_Overdrive6_FuzzyController_Caps
++@ stub ADL2_Overdrive6_MaxClockAdjust_Get
++@ stub ADL2_Overdrive6_PowerControlInfo_Get
++@ stub ADL2_Overdrive6_PowerControlInfo_Get_X2
++@ stub ADL2_Overdrive6_PowerControl_Caps
++@ stub ADL2_Overdrive6_PowerControl_Get
++@ stub ADL2_Overdrive6_PowerControl_Set
++@ stub ADL2_Overdrive6_StateEx_Get
++@ stub ADL2_Overdrive6_StateEx_Set
++@ stub ADL2_Overdrive6_StateInfo_Get
++@ stub ADL2_Overdrive6_State_Reset
++@ stub ADL2_Overdrive6_State_Set
++@ stub ADL2_Overdrive6_TargetTemperatureData_Get
++@ stub ADL2_Overdrive6_TargetTemperatureData_Set
++@ stub ADL2_Overdrive6_TargetTemperatureRangeInfo_Get
++@ stub ADL2_Overdrive6_TemperatureEx_Get
++@ stub ADL2_Overdrive6_Temperature_Get
++@ stub ADL2_Overdrive6_ThermalController_Caps
++@ stub ADL2_Overdrive6_ThermalLimitUnlock_Get
++@ stub ADL2_Overdrive6_ThermalLimitUnlock_Set
++@ stub ADL2_Overdrive6_VoltageControlInfo_Get
++@ stub ADL2_Overdrive6_VoltageControl_Get
++@ stub ADL2_Overdrive6_VoltageControl_Set
++@ stub ADL2_Overdrive8_Current_SettingX2_Get
++@ stub ADL2_Overdrive8_Current_SettingX3_Get
++@ stub ADL2_Overdrive8_Current_Setting_Get
++@ stub ADL2_Overdrive8_Init_SettingX2_Get
++@ stub ADL2_Overdrive8_Init_Setting_Get
++@ stub ADL2_Overdrive8_PMLogSenorRange_Caps
++@ stub ADL2_Overdrive8_PMLogSenorType_Support_Get
++@ stub ADL2_Overdrive8_PMLog_ShareMemory_Read
++@ stub ADL2_Overdrive8_PMLog_ShareMemory_Start
++@ stub ADL2_Overdrive8_PMLog_ShareMemory_Stop
++@ stub ADL2_Overdrive8_PMLog_ShareMemory_Support
++@ stub ADL2_Overdrive8_Setting_Set
++@ stub ADL2_OverdriveN_AutoWattman_Caps
++@ stub ADL2_OverdriveN_AutoWattman_Get
++@ stub ADL2_OverdriveN_AutoWattman_Set
++@ stub ADL2_OverdriveN_CapabilitiesX2_Get
++@ stub ADL2_OverdriveN_Capabilities_Get
++@ stub ADL2_OverdriveN_CountOfEvents_Get
++@ stub ADL2_OverdriveN_FanControl_Get
++@ stub ADL2_OverdriveN_FanControl_Set
++@ stub ADL2_OverdriveN_MemoryClocksX2_Get
++@ stub ADL2_OverdriveN_MemoryClocksX2_Set
++@ stub ADL2_OverdriveN_MemoryClocks_Get
++@ stub ADL2_OverdriveN_MemoryClocks_Set
++@ stub ADL2_OverdriveN_MemoryTimingLevel_Get
++@ stub ADL2_OverdriveN_MemoryTimingLevel_Set
++@ stub ADL2_OverdriveN_PerformanceStatus_Get
++@ stub ADL2_OverdriveN_PowerLimit_Get
++@ stub ADL2_OverdriveN_PowerLimit_Set
++@ stub ADL2_OverdriveN_SCLKAutoOverClock_Get
++@ stub ADL2_OverdriveN_SCLKAutoOverClock_Set
++@ stub ADL2_OverdriveN_SettingsExt_Get
++@ stub ADL2_OverdriveN_SettingsExt_Set
++@ stub ADL2_OverdriveN_SystemClocksX2_Get
++@ stub ADL2_OverdriveN_SystemClocksX2_Set
++@ stub ADL2_OverdriveN_SystemClocks_Get
++@ stub ADL2_OverdriveN_SystemClocks_Set
++@ stub ADL2_OverdriveN_Temperature_Get
++@ stub ADL2_OverdriveN_Test_Set
++@ stub ADL2_OverdriveN_ThrottleNotification_Get
++@ stub ADL2_OverdriveN_ZeroRPMFan_Get
++@ stub ADL2_OverdriveN_ZeroRPMFan_Set
++@ stub ADL2_Overdrive_Caps
++@ stub ADL2_PPLogSettings_Get
++@ stub ADL2_PPLogSettings_Set
++@ stub ADL2_PPW_Caps
++@ stub ADL2_PPW_Status_Get
++@ stub ADL2_PPW_Status_Set
++@ stub ADL2_PageMigration_Settings_Get
++@ stub ADL2_PageMigration_Settings_Set
++@ stub ADL2_PerGPU_GDEvent_Register
++@ stub ADL2_PerGPU_GDEvent_UnRegister
++@ stub ADL2_PerfTuning_Status_Get
++@ stub ADL2_PerfTuning_Status_Set
++@ stub ADL2_PerformanceTuning_Caps
++@ stub ADL2_PowerStates_Get
++@ stub ADL2_PowerXpress_AncillaryDevices_Get
++@ stub ADL2_PowerXpress_Config_Caps
++@ stub ADL2_PowerXpress_Configuration_Get
++@ stub ADL2_PowerXpress_ExtendedBatteryMode_Caps
++@ stub ADL2_PowerXpress_ExtendedBatteryMode_Get
++@ stub ADL2_PowerXpress_ExtendedBatteryMode_Set
++@ stub ADL2_PowerXpress_LongIdleDetect_Get
++@ stub ADL2_PowerXpress_LongIdleDetect_Set
++@ stub ADL2_PowerXpress_PowerControlMode_Get
++@ stub ADL2_PowerXpress_PowerControlMode_Set
++@ stub ADL2_PowerXpress_Scheme_Get
++@ stub ADL2_PowerXpress_Scheme_Set
++@ stub ADL2_RIS_Settings_Get
++@ stub ADL2_RIS_Settings_Set
++@ stub ADL2_RegisterEvent
++@ stub ADL2_RegisterEventX2
++@ stub ADL2_Remap
++@ stub ADL2_RemoteDisplay_Destroy
++@ stub ADL2_RemoteDisplay_Display_Acquire
++@ stub ADL2_RemoteDisplay_Display_Release
++@ stub ADL2_RemoteDisplay_Display_Release_All
++@ stub ADL2_RemoteDisplay_Hdcp20_Create
++@ stub ADL2_RemoteDisplay_Hdcp20_Destroy
++@ stub ADL2_RemoteDisplay_Hdcp20_Notify
++@ stub ADL2_RemoteDisplay_Hdcp20_Process
++@ stub ADL2_RemoteDisplay_IEPort_Set
++@ stub ADL2_RemoteDisplay_Initialize
++@ stub ADL2_RemoteDisplay_Nofitiation_Register
++@ stub ADL2_RemoteDisplay_Notification_UnRegister
++@ stub ADL2_RemoteDisplay_Support_Caps
++@ stub ADL2_RemoteDisplay_VirtualWirelessAdapter_InUse_Get
++@ stub ADL2_RemoteDisplay_VirtualWirelessAdapter_Info_Get
++@ stub ADL2_RemoteDisplay_VirtualWirelessAdapter_RadioState_Get
++@ stub ADL2_RemoteDisplay_VirtualWirelessAdapter_WPSSetting_Change
++@ stub ADL2_RemoteDisplay_VirtualWirelessAdapter_WPSSetting_Get
++@ stub ADL2_RemoteDisplay_WFDDeviceInfo_Get
++@ stub ADL2_RemoteDisplay_WFDDeviceName_Change
++@ stub ADL2_RemoteDisplay_WFDDevice_StatusInfo_Get
++@ stub ADL2_RemoteDisplay_WFDDiscover_Start
++@ stub ADL2_RemoteDisplay_WFDDiscover_Stop
++@ stub ADL2_RemoteDisplay_WFDLink_Connect
++@ stub ADL2_RemoteDisplay_WFDLink_Creation_Accept
++@ stub ADL2_RemoteDisplay_WFDLink_Disconnect
++@ stub ADL2_RemoteDisplay_WFDLink_WPS_Process
++@ stub ADL2_RemoteDisplay_WFDWDSPSettings_Set
++@ stub ADL2_RemoteDisplay_WirelessDisplayEnableDisable_Commit
++@ stub ADL2_RemotePlay_ControlFlags_Set
++@ stub ADL2_ScreenPoint_AudioMappingInfo_Get
++@ stub ADL2_Send
++@ stub ADL2_SendX2
++@ stub ADL2_Stereo3D_2DPackedFormat_Set
++@ stub ADL2_Stereo3D_3DCursorOffset_Get
++@ stub ADL2_Stereo3D_3DCursorOffset_Set
++@ stub ADL2_Stereo3D_CurrentFormat_Get
++@ stub ADL2_Stereo3D_Info_Get
++@ stub ADL2_Stereo3D_Modes_Get
++@ stub ADL2_SwitchableGraphics_Applications_Get
++@ stub ADL2_TV_Standard_Get
++@ stub ADL2_TV_Standard_Set
++@ stub ADL2_TurboSyncSupport_Get
++@ stub ADL2_UnRegisterEvent
++@ stub ADL2_UnRegisterEventX2
++@ stub ADL2_User_Settings_Notify
++@ stub ADL2_WS_Overdrive_Caps
++@ stub ADL2_Win_IsHybridAI
++@ stub ADL2_Workstation_8BitGrayscale_Get
++@ stub ADL2_Workstation_8BitGrayscale_Set
++@ stub ADL2_Workstation_AdapterNumOfGLSyncConnectors_Get
++@ stub ADL2_Workstation_Caps
++@ stub ADL2_Workstation_DeepBitDepthX2_Get
++@ stub ADL2_Workstation_DeepBitDepthX2_Set
++@ stub ADL2_Workstation_DeepBitDepth_Get
++@ stub ADL2_Workstation_DeepBitDepth_Set
++@ stub ADL2_Workstation_DisplayGLSyncMode_Get
++@ stub ADL2_Workstation_DisplayGLSyncMode_Set
++@ stub ADL2_Workstation_DisplayGenlockCapable_Get
++@ stub ADL2_Workstation_ECCData_Get
++@ stub ADL2_Workstation_ECCX2_Get
++@ stub ADL2_Workstation_ECC_Caps
++@ stub ADL2_Workstation_ECC_Get
++@ stub ADL2_Workstation_ECC_Set
++@ stub ADL2_Workstation_GLSyncCounters_Get
++@ stub ADL2_Workstation_GLSyncGenlockConfiguration_Get
++@ stub ADL2_Workstation_GLSyncGenlockConfiguration_Set
++@ stub ADL2_Workstation_GLSyncModuleDetect_Get
++@ stub ADL2_Workstation_GLSyncModuleInfo_Get
++@ stub ADL2_Workstation_GLSyncPortState_Get
++@ stub ADL2_Workstation_GLSyncPortState_Set
++@ stub ADL2_Workstation_GLSyncSupportedTopology_Get
++@ stub ADL2_Workstation_GlobalEDIDPersistence_Get
++@ stub ADL2_Workstation_GlobalEDIDPersistence_Set
++@ stub ADL2_Workstation_LoadBalancing_Caps
++@ stub ADL2_Workstation_LoadBalancing_Get
++@ stub ADL2_Workstation_LoadBalancing_Set
++@ stub ADL2_Workstation_RAS_ErrorCounts_Get
++@ stub ADL2_Workstation_RAS_ErrorCounts_Reset
++@ stub ADL2_Workstation_SDISegmentList_Get
++@ stub ADL2_Workstation_SDI_Caps
++@ stub ADL2_Workstation_SDI_Get
++@ stub ADL2_Workstation_SDI_Set
++@ stub ADL2_Workstation_Stereo_Get
++@ stub ADL2_Workstation_Stereo_Set
++@ stub ADL2_Workstation_UnsupportedDisplayModes_Enable
++@ stub ADL_ADC_CurrentProfileFromDrv_Get
++@ stub ADL_ADC_Display_AdapterDeviceProfileEx_Get
++@ stub ADL_ADC_DrvDataToProfile_Copy
++@ stub ADL_ADC_FindClosestMode_Get
++@ stub ADL_ADC_IsDevModeEqual_Get
++@ stub ADL_ADC_Profile_Apply
++@ stub ADL_APO_AudioDelayAdjustmentInfo_Get
++@ stub ADL_APO_AudioDelay_Restore
++@ stub ADL_APO_AudioDelay_Set
++@ stub ADL_AdapterLimitation_Caps
++@ stub ADL_AdapterX2_Caps
++@ stub ADL_Adapter_ASICFamilyType_Get
++@ stub ADL_Adapter_ASICInfo_Get
++@ stub ADL_Adapter_Accessibility_Get
++@ stub ADL_Adapter_Active_Get
++@ stub ADL_Adapter_Active_Set
++@ stub ADL_Adapter_Active_SetPrefer
++@ stub ADL_Adapter_AdapterInfoX2_Get
++@ stub ADL_Adapter_AdapterInfo_Get
++@ stub ADL_Adapter_AdapterList_Disable
++@ stub ADL_Adapter_Aspects_Get
++@ stub ADL_Adapter_AudioChannelSplitConfiguration_Get
++@ stub ADL_Adapter_AudioChannelSplit_Disable
++@ stub ADL_Adapter_AudioChannelSplit_Enable
++@ stub ADL_Adapter_BigSw_Info_Get
++@ stub ADL_Adapter_BlackAndWhiteLevelSupport_Get
++@ stub ADL_Adapter_BlackAndWhiteLevel_Get
++@ stub ADL_Adapter_BlackAndWhiteLevel_Set
++@ stub ADL_Adapter_BoardLayout_Get
++@ stub ADL_Adapter_Caps
++@ stub ADL_Adapter_ChipSetInfo_Get
++@ stub ADL_Adapter_ConfigMemory_Cap
++@ stub ADL_Adapter_ConfigMemory_Get
++@ stub ADL_Adapter_ConfigureState_Get
++@ stub ADL_Adapter_ConnectionData_Get
++@ stub ADL_Adapter_ConnectionData_Remove
++@ stub ADL_Adapter_ConnectionData_Set
++@ stub ADL_Adapter_ConnectionState_Get
++@ stub ADL_Adapter_CrossDisplayPlatformInfo_Get
++@ stub ADL_Adapter_CrossdisplayAdapterRole_Caps
++@ stub ADL_Adapter_CrossdisplayInfoX2_Set
++@ stub ADL_Adapter_CrossdisplayInfo_Get
++@ stub ADL_Adapter_CrossdisplayInfo_Set
++@ stub ADL_Adapter_CrossfireX2_Get
++@ stub ADL_Adapter_Crossfire_Caps
++@ stub ADL_Adapter_Crossfire_Get
++@ stub ADL_Adapter_Crossfire_Set
++@ stub ADL_Adapter_DefaultAudioChannelTable_Load
++@ stub ADL_Adapter_DisplayAudioEndpoint_Enable
++@ stub ADL_Adapter_DisplayAudioEndpoint_Mute
++@ stub ADL_Adapter_DisplayAudioInfo_Get
++@ stub ADL_Adapter_DisplayGTCCaps_Get
++@ stub ADL_Adapter_Display_Caps
++@ stub ADL_Adapter_DriverSettings_Get
++@ stub ADL_Adapter_DriverSettings_Set
++@ stub ADL_Adapter_EDIDManagement_Caps
++@ stub ADL_Adapter_EmulationMode_Set
++@ stub ADL_Adapter_ExtInfo_Get
++@ stub ADL_Adapter_Gamma_Get
++@ stub ADL_Adapter_Gamma_Set
++@ stub ADL_Adapter_ID_Get
++@ stub ADL_Adapter_LocalDisplayConfig_Get
++@ stub ADL_Adapter_LocalDisplayConfig_Set
++@ stub ADL_Adapter_LocalDisplayState_Get
++@ stub ADL_Adapter_MaxCursorSize_Get
++@ stub ADL_Adapter_MemoryInfo2_Get
++@ stub ADL_Adapter_MemoryInfo_Get
++@ stub ADL_Adapter_MirabilisSupport_Get
++@ stub ADL_Adapter_ModeSwitch
++@ stub ADL_Adapter_ModeTimingOverride_Caps
++@ stub ADL_Adapter_Modes_ReEnumerate
++@ stub ADL_Adapter_NumberOfActivatableSources_Get
++@ stub ADL_Adapter_NumberOfAdapters_Get
++@ stub ADL_Adapter_ObservedClockInfo_Get
++@ stub ADL_Adapter_ObservedGameClockInfo_Get
++@ stub ADL_Adapter_Primary_Get
++@ stub ADL_Adapter_Primary_Set
++@ stub ADL_Adapter_RegValueInt_Get
++@ stub ADL_Adapter_RegValueInt_Set
++@ stub ADL_Adapter_RegValueString_Get
++@ stub ADL_Adapter_RegValueString_Set
++@ stub ADL_Adapter_SWInfo_Get
++@ stub ADL_Adapter_Speed_Caps
++@ stub ADL_Adapter_Speed_Get
++@ stub ADL_Adapter_Speed_Set
++@ stub ADL_Adapter_SupportedConnections_Get
++@ stub ADL_Adapter_Tear_Free_Cap
++@ stub ADL_Adapter_VariBrightEnable_Set
++@ stub ADL_Adapter_VariBrightLevel_Get
++@ stub ADL_Adapter_VariBrightLevel_Set
++@ stub ADL_Adapter_VariBright_Caps
++@ stub ADL_Adapter_VideoBiosInfo_Get
++@ stub ADL_Adapter_VideoTheaterModeInfo_Get
++@ stub ADL_Adapter_VideoTheaterModeInfo_Set
++@ stub ADL_ApplicationProfiles_Applications_Get
++@ stub ADL_ApplicationProfiles_ConvertToCompact
++@ stub ADL_ApplicationProfiles_DriverAreaPrivacy_Get
++@ stub ADL_ApplicationProfiles_GetCustomization
++@ stub ADL_ApplicationProfiles_HitListsX2_Get
++@ stub ADL_ApplicationProfiles_HitLists_Get
++@ stub ADL_ApplicationProfiles_ProfileApplicationX2_Assign
++@ stub ADL_ApplicationProfiles_ProfileApplication_Assign
++@ stub ADL_ApplicationProfiles_ProfileOfAnApplicationX2_Search
++@ stub ADL_ApplicationProfiles_ProfileOfAnApplication_InMemorySearch
++@ stub ADL_ApplicationProfiles_ProfileOfAnApplication_Search
++@ stub ADL_ApplicationProfiles_Profile_Create
++@ stub ADL_ApplicationProfiles_Profile_Exist
++@ stub ADL_ApplicationProfiles_Profile_Remove
++@ stub ADL_ApplicationProfiles_PropertyType_Get
++@ stub ADL_ApplicationProfiles_Release_Get
++@ stub ADL_ApplicationProfiles_RemoveApplication
++@ stub ADL_ApplicationProfiles_StatusInfo_Get
++@ stub ADL_ApplicationProfiles_System_Reload
++@ stub ADL_ApplicationProfiles_User_Load
++@ stub ADL_ApplicationProfiles_User_Unload
++@ stub ADL_Audio_CurrentSampleRate_Get
++@ stub ADL_CDS_UnsafeMode_Set
++@ stub ADL_CV_DongleSettings_Get
++@ stub ADL_CV_DongleSettings_Reset
++@ stub ADL_CV_DongleSettings_Set
++@ stub ADL_DFP_AllowOnlyCETimings_Get
++@ stub ADL_DFP_AllowOnlyCETimings_Set
++@ stub ADL_DFP_BaseAudioSupport_Get
++@ stub ADL_DFP_GPUScalingEnable_Get
++@ stub ADL_DFP_GPUScalingEnable_Set
++@ stub ADL_DFP_HDMISupport_Get
++@ stub ADL_DFP_MVPUAnalogSupport_Get
++@ stub ADL_DFP_PixelFormat_Caps
++@ stub ADL_DFP_PixelFormat_Get
++@ stub ADL_DFP_PixelFormat_Set
++@ stub ADL_DisplayScaling_Set
++@ stub ADL_Display_AdapterID_Get
++@ stub ADL_Display_AdjustCaps_Get
++@ stub ADL_Display_AdjustmentCoherent_Get
++@ stub ADL_Display_AdjustmentCoherent_Set
++@ stub ADL_Display_AudioMappingInfo_Get
++@ stub ADL_Display_AvivoColor_Get
++@ stub ADL_Display_AvivoCurrentColor_Set
++@ stub ADL_Display_AvivoDefaultColor_Set
++@ stub ADL_Display_BackLight_Get
++@ stub ADL_Display_BackLight_Set
++@ stub ADL_Display_BezelOffsetSteppingSize_Get
++@ stub ADL_Display_BezelOffset_Set
++@ stub ADL_Display_BezelSupported_Validate
++@ stub ADL_Display_Capabilities_Get
++@ stub ADL_Display_ColorCaps_Get
++@ stub ADL_Display_ColorDepth_Get
++@ stub ADL_Display_ColorDepth_Set
++@ stub ADL_Display_ColorTemperatureSource_Get
++@ stub ADL_Display_ColorTemperatureSource_Set
++@ stub ADL_Display_Color_Get
++@ stub ADL_Display_Color_Set
++@ stub ADL_Display_ConnectedDisplays_Get
++@ stub ADL_Display_ContainerID_Get
++@ stub ADL_Display_ControllerOverlayAdjustmentCaps_Get
++@ stub ADL_Display_ControllerOverlayAdjustmentData_Get
++@ stub ADL_Display_ControllerOverlayAdjustmentData_Set
++@ stub ADL_Display_CurrentPixelClock_Get
++@ stub ADL_Display_CustomizedModeListNum_Get
++@ stub ADL_Display_CustomizedModeList_Get
++@ stub ADL_Display_CustomizedMode_Add
++@ stub ADL_Display_CustomizedMode_Delete
++@ stub ADL_Display_CustomizedMode_Validate
++@ stub ADL_Display_DCE_Get
++@ stub ADL_Display_DCE_Set
++@ stub ADL_Display_DDCBlockAccess_Get
++@ stub ADL_Display_DDCInfo2_Get
++@ stub ADL_Display_DDCInfo_Get
++@ stub ADL_Display_Deflicker_Get
++@ stub ADL_Display_Deflicker_Set
++@ stub ADL_Display_DeviceConfig_Get
++@ stub ADL_Display_DisplayContent_Cap
++@ stub ADL_Display_DisplayContent_Get
++@ stub ADL_Display_DisplayContent_Set
++@ stub ADL_Display_DisplayInfo_Get
++@ stub ADL_Display_DisplayMapConfig_Get
++@ stub ADL_Display_DisplayMapConfig_PossibleAddAndRemove
++@ stub ADL_Display_DisplayMapConfig_Set
++@ stub ADL_Display_DisplayMapConfig_Validate
++@ stub ADL_Display_DitherState_Get
++@ stub ADL_Display_DitherState_Set
++@ stub ADL_Display_Downscaling_Caps
++@ stub ADL_Display_DpMstInfo_Get
++@ stub ADL_Display_EdidData_Get
++@ stub ADL_Display_EdidData_Set
++@ stub ADL_Display_EnumDisplays_Get
++@ stub ADL_Display_FilterSVideo_Get
++@ stub ADL_Display_FilterSVideo_Set
++@ stub ADL_Display_ForcibleDisplay_Get
++@ stub ADL_Display_ForcibleDisplay_Set
++@ stub ADL_Display_FormatsOverride_Get
++@ stub ADL_Display_FormatsOverride_Set
++@ stub ADL_Display_FreeSyncState_Get
++@ stub ADL_Display_FreeSyncState_Set
++@ stub ADL_Display_FreeSync_Cap
++@ stub ADL_Display_GamutMapping_Get
++@ stub ADL_Display_GamutMapping_Reset
++@ stub ADL_Display_GamutMapping_Set
++@ stub ADL_Display_Gamut_Caps
++@ stub ADL_Display_Gamut_Get
++@ stub ADL_Display_Gamut_Set
++@ stub ADL_Display_ImageExpansion_Get
++@ stub ADL_Display_ImageExpansion_Set
++@ stub ADL_Display_InfoPacket_Get
++@ stub ADL_Display_InfoPacket_Set
++@ stub ADL_Display_LCDRefreshRateCapability_Get
++@ stub ADL_Display_LCDRefreshRateOptions_Get
++@ stub ADL_Display_LCDRefreshRateOptions_Set
++@ stub ADL_Display_LCDRefreshRate_Get
++@ stub ADL_Display_LCDRefreshRate_Set
++@ stub ADL_Display_Limits_Get
++@ stub ADL_Display_MVPUCaps_Get
++@ stub ADL_Display_MVPUStatus_Get
++@ stub ADL_Display_ModeTimingOverrideInfo_Get
++@ stub ADL_Display_ModeTimingOverrideListX2_Get
++@ stub ADL_Display_ModeTimingOverrideList_Get
++@ stub ADL_Display_ModeTimingOverrideX2_Get
++@ stub ADL_Display_ModeTimingOverride_Delete
++@ stub ADL_Display_ModeTimingOverride_Get
++@ stub ADL_Display_ModeTimingOverride_Set
++@ stub ADL_Display_Modes_Get
++@ stub ADL_Display_Modes_Set
++@ stub ADL_Display_MonitorPowerState_Set
++@ stub ADL_Display_NativeAUXChannel_Access
++@ stub ADL_Display_NeedWorkaroundFor5Clone_Get
++@ stub ADL_Display_NumberOfDisplays_Get
++@ stub ADL_Display_ODClockConfig_Set
++@ stub ADL_Display_ODClockInfo_Get
++@ stub ADL_Display_Overlap_Set
++@ stub ADL_Display_Overscan_Get
++@ stub ADL_Display_Overscan_Set
++@ stub ADL_Display_PixelClockAllowableRange_Set
++@ stub ADL_Display_PixelClockCaps_Get
++@ stub ADL_Display_PixelFormat_Get
++@ stub ADL_Display_PixelFormat_Set
++@ stub ADL_Display_Position_Get
++@ stub ADL_Display_Position_Set
++@ stub ADL_Display_PossibleMapping_Get
++@ stub ADL_Display_PossibleMode_Get
++@ stub ADL_Display_PowerXpressActiveGPU_Get
++@ stub ADL_Display_PowerXpressActiveGPU_Set
++@ stub ADL_Display_PowerXpressActvieGPUR2_Get
++@ stub ADL_Display_PowerXpressVersion_Get
++@ stub ADL_Display_PowerXpress_AutoSwitchConfig_Get
++@ stub ADL_Display_PowerXpress_AutoSwitchConfig_Set
++@ stub ADL_Display_PreservedAspectRatio_Get
++@ stub ADL_Display_PreservedAspectRatio_Set
++@ stub ADL_Display_Property_Get
++@ stub ADL_Display_Property_Set
++@ stub ADL_Display_RcDisplayAdjustment
++@ stub ADL_Display_ReGammaCoefficients_Get
++@ stub ADL_Display_ReGammaCoefficients_Set
++@ stub ADL_Display_ReducedBlanking_Get
++@ stub ADL_Display_ReducedBlanking_Set
++@ stub ADL_Display_RegammaR1_Get
++@ stub ADL_Display_RegammaR1_Set
++@ stub ADL_Display_Regamma_Get
++@ stub ADL_Display_Regamma_Set
++@ stub ADL_Display_SLSGrid_Caps
++@ stub ADL_Display_SLSMapConfigX2_Get
++@ stub ADL_Display_SLSMapConfig_Create
++@ stub ADL_Display_SLSMapConfig_Delete
++@ stub ADL_Display_SLSMapConfig_Get
++@ stub ADL_Display_SLSMapConfig_Rearrange
++@ stub ADL_Display_SLSMapConfig_SetState
++@ stub ADL_Display_SLSMapIndexList_Get
++@ stub ADL_Display_SLSMapIndex_Get
++@ stub ADL_Display_SLSMiddleMode_Get
++@ stub ADL_Display_SLSMiddleMode_Set
++@ stub ADL_Display_SLSRecords_Get
++@ stub ADL_Display_Sharpness_Caps
++@ stub ADL_Display_Sharpness_Get
++@ stub ADL_Display_Sharpness_Info_Get
++@ stub ADL_Display_Sharpness_Set
++@ stub ADL_Display_Size_Get
++@ stub ADL_Display_Size_Set
++@ stub ADL_Display_SourceContentAttribute_Get
++@ stub ADL_Display_SourceContentAttribute_Set
++@ stub ADL_Display_SplitDisplay_Caps
++@ stub ADL_Display_SplitDisplay_Get
++@ stub ADL_Display_SplitDisplay_RestoreDesktopConfiguration
++@ stub ADL_Display_SplitDisplay_Set
++@ stub ADL_Display_SupportedColorDepth_Get
++@ stub ADL_Display_SupportedPixelFormat_Get
++@ stub ADL_Display_SwitchingCapability_Get
++@ stub ADL_Display_TVCaps_Get
++@ stub ADL_Display_TargetTiming_Get
++@ stub ADL_Display_UnderScan_Auto_Get
++@ stub ADL_Display_UnderScan_Auto_Set
++@ stub ADL_Display_Underscan_Get
++@ stub ADL_Display_Underscan_Set
++@ stub ADL_Display_Vector_Get
++@ stub ADL_Display_ViewPort_Cap
++@ stub ADL_Display_ViewPort_Get
++@ stub ADL_Display_ViewPort_Set
++@ stub ADL_Display_WriteAndReadI2C
++@ stub ADL_Display_WriteAndReadI2CLargePayload
++@ stub ADL_Display_WriteAndReadI2CRev_Get
++@ stub ADL_Flush_Driver_Data
++@ stub ADL_Graphics_Platform_Get
++@ stdcall ADL_Graphics_Versions_Get(ptr)
++@ stub ADL_MMD_FeatureList_Get
++@ stub ADL_MMD_FeatureValuesX2_Get
++@ stub ADL_MMD_FeatureValuesX2_Set
++@ stub ADL_MMD_FeatureValues_Get
++@ stub ADL_MMD_FeatureValues_Set
++@ stub ADL_MMD_FeaturesX2_Caps
++@ stub ADL_MMD_Features_Caps
++@ stub ADL_MMD_VideoAdjustInfo_Get
++@ stub ADL_MMD_VideoAdjustInfo_Set
++@ stub ADL_MMD_VideoColor_Caps
++@ stub ADL_MMD_VideoColor_Get
++@ stub ADL_MMD_VideoColor_Set
++@ stub ADL_MMD_Video_Caps
++@ stub ADL_Main_ControlX2_Create
++@ stdcall ADL_Main_Control_Create(ptr long)
++@ stdcall ADL_Main_Control_Destroy()
++@ stub ADL_Main_Control_GetProcAddress
++@ stub ADL_Main_Control_IsFunctionValid
++@ stub ADL_Main_Control_Refresh
++@ stub ADL_Main_LogDebug_Set
++@ stub ADL_Main_LogError_Set
++@ stub ADL_Overdrive5_CurrentActivity_Get
++@ stub ADL_Overdrive5_FanSpeedInfo_Get
++@ stub ADL_Overdrive5_FanSpeedToDefault_Set
++@ stub ADL_Overdrive5_FanSpeed_Get
++@ stub ADL_Overdrive5_FanSpeed_Set
++@ stub ADL_Overdrive5_ODParameters_Get
++@ stub ADL_Overdrive5_ODPerformanceLevels_Get
++@ stub ADL_Overdrive5_ODPerformanceLevels_Set
++@ stub ADL_Overdrive5_PowerControlAbsValue_Caps
++@ stub ADL_Overdrive5_PowerControlAbsValue_Get
++@ stub ADL_Overdrive5_PowerControlAbsValue_Set
++@ stub ADL_Overdrive5_PowerControlInfo_Get
++@ stub ADL_Overdrive5_PowerControl_Caps
++@ stub ADL_Overdrive5_PowerControl_Get
++@ stub ADL_Overdrive5_PowerControl_Set
++@ stub ADL_Overdrive5_Temperature_Get
++@ stub ADL_Overdrive5_ThermalDevices_Enum
++@ stub ADL_Overdrive6_AdvancedFan_Caps
++@ stub ADL_Overdrive6_CapabilitiesEx_Get
++@ stub ADL_Overdrive6_Capabilities_Get
++@ stub ADL_Overdrive6_CurrentStatus_Get
++@ stub ADL_Overdrive6_FanPWMLimitData_Get
++@ stub ADL_Overdrive6_FanPWMLimitData_Set
++@ stub ADL_Overdrive6_FanPWMLimitRangeInfo_Get
++@ stub ADL_Overdrive6_FanSpeed_Get
++@ stub ADL_Overdrive6_FanSpeed_Reset
++@ stub ADL_Overdrive6_FanSpeed_Set
++@ stub ADL_Overdrive6_FuzzyController_Caps
++@ stub ADL_Overdrive6_MaxClockAdjust_Get
++@ stub ADL_Overdrive6_PowerControlInfo_Get
++@ stub ADL_Overdrive6_PowerControl_Caps
++@ stub ADL_Overdrive6_PowerControl_Get
++@ stub ADL_Overdrive6_PowerControl_Set
++@ stub ADL_Overdrive6_StateEx_Get
++@ stub ADL_Overdrive6_StateEx_Set
++@ stub ADL_Overdrive6_StateInfo_Get
++@ stub ADL_Overdrive6_State_Reset
++@ stub ADL_Overdrive6_State_Set
++@ stub ADL_Overdrive6_TargetTemperatureData_Get
++@ stub ADL_Overdrive6_TargetTemperatureData_Set
++@ stub ADL_Overdrive6_TargetTemperatureRangeInfo_Get
++@ stub ADL_Overdrive6_Temperature_Get
++@ stub ADL_Overdrive6_ThermalController_Caps
++@ stub ADL_Overdrive6_ThermalLimitUnlock_Get
++@ stub ADL_Overdrive6_ThermalLimitUnlock_Set
++@ stub ADL_Overdrive6_VoltageControlInfo_Get
++@ stub ADL_Overdrive6_VoltageControl_Get
++@ stub ADL_Overdrive6_VoltageControl_Set
++@ stub ADL_Overdrive_Caps
++@ stub ADL_PowerXpress_AncillaryDevices_Get
++@ stub ADL_PowerXpress_Config_Caps
++@ stub ADL_PowerXpress_ExtendedBatteryMode_Caps
++@ stub ADL_PowerXpress_ExtendedBatteryMode_Get
++@ stub ADL_PowerXpress_ExtendedBatteryMode_Set
++@ stub ADL_PowerXpress_LongIdleDetect_Get
++@ stub ADL_PowerXpress_LongIdleDetect_Set
++@ stub ADL_PowerXpress_PowerControlMode_Get
++@ stub ADL_PowerXpress_PowerControlMode_Set
++@ stub ADL_PowerXpress_Scheme_Get
++@ stub ADL_PowerXpress_Scheme_Set
++@ stub ADL_Remap
++@ stub ADL_RemoteDisplay_Destroy
++@ stub ADL_RemoteDisplay_Display_Acquire
++@ stub ADL_RemoteDisplay_Display_Release
++@ stub ADL_RemoteDisplay_Display_Release_All
++@ stub ADL_RemoteDisplay_Hdcp20_Create
++@ stub ADL_RemoteDisplay_Hdcp20_Destroy
++@ stub ADL_RemoteDisplay_Hdcp20_Notify
++@ stub ADL_RemoteDisplay_Hdcp20_Process
++@ stub ADL_RemoteDisplay_IEPort_Set
++@ stub ADL_RemoteDisplay_Initialize
++@ stub ADL_RemoteDisplay_Nofitiation_Register
++@ stub ADL_RemoteDisplay_Notification_UnRegister
++@ stub ADL_RemoteDisplay_Support_Caps
++@ stub ADL_RemoteDisplay_VirtualWirelessAdapter_InUse_Get
++@ stub ADL_RemoteDisplay_VirtualWirelessAdapter_Info_Get
++@ stub ADL_RemoteDisplay_VirtualWirelessAdapter_RadioState_Get
++@ stub ADL_RemoteDisplay_VirtualWirelessAdapter_WPSSetting_Change
++@ stub ADL_RemoteDisplay_VirtualWirelessAdapter_WPSSetting_Get
++@ stub ADL_RemoteDisplay_WFDDeviceInfo_Get
++@ stub ADL_RemoteDisplay_WFDDeviceName_Change
++@ stub ADL_RemoteDisplay_WFDDevice_StatusInfo_Get
++@ stub ADL_RemoteDisplay_WFDDiscover_Start
++@ stub ADL_RemoteDisplay_WFDDiscover_Stop
++@ stub ADL_RemoteDisplay_WFDLink_Connect
++@ stub ADL_RemoteDisplay_WFDLink_Creation_Accept
++@ stub ADL_RemoteDisplay_WFDLink_Disconnect
++@ stub ADL_RemoteDisplay_WFDLink_WPS_Process
++@ stub ADL_RemoteDisplay_WFDWDSPSettings_Set
++@ stub ADL_RemoteDisplay_WirelessDisplayEnableDisable_Commit
++@ stub ADL_ScreenPoint_AudioMappingInfo_Get
++@ stub ADL_Stereo3D_2DPackedFormat_Set
++@ stub ADL_Stereo3D_3DCursorOffset_Get
++@ stub ADL_Stereo3D_3DCursorOffset_Set
++@ stub ADL_Stereo3D_CurrentFormat_Get
++@ stub ADL_Stereo3D_Info_Get
++@ stub ADL_Stereo3D_Modes_Get
++@ stub ADL_TV_Standard_Get
++@ stub ADL_TV_Standard_Set
++@ stub ADL_Win_IsHybridAI
++@ stub ADL_Workstation_8BitGrayscale_Get
++@ stub ADL_Workstation_8BitGrayscale_Set
++@ stub ADL_Workstation_AdapterNumOfGLSyncConnectors_Get
++@ stub ADL_Workstation_Caps
++@ stub ADL_Workstation_DeepBitDepthX2_Get
++@ stub ADL_Workstation_DeepBitDepthX2_Set
++@ stub ADL_Workstation_DeepBitDepth_Get
++@ stub ADL_Workstation_DeepBitDepth_Set
++@ stub ADL_Workstation_DisplayGLSyncMode_Get
++@ stub ADL_Workstation_DisplayGLSyncMode_Set
++@ stub ADL_Workstation_DisplayGenlockCapable_Get
++@ stub ADL_Workstation_ECCData_Get
++@ stub ADL_Workstation_ECCX2_Get
++@ stub ADL_Workstation_ECC_Caps
++@ stub ADL_Workstation_ECC_Get
++@ stub ADL_Workstation_ECC_Set
++@ stub ADL_Workstation_GLSyncCounters_Get
++@ stub ADL_Workstation_GLSyncGenlockConfiguration_Get
++@ stub ADL_Workstation_GLSyncGenlockConfiguration_Set
++@ stub ADL_Workstation_GLSyncModuleDetect_Get
++@ stub ADL_Workstation_GLSyncModuleInfo_Get
++@ stub ADL_Workstation_GLSyncPortState_Get
++@ stub ADL_Workstation_GLSyncPortState_Set
++@ stub ADL_Workstation_GLSyncSupportedTopology_Get
++@ stub ADL_Workstation_GlobalEDIDPersistence_Get
++@ stub ADL_Workstation_GlobalEDIDPersistence_Set
++@ stub ADL_Workstation_LoadBalancing_Caps
++@ stub ADL_Workstation_LoadBalancing_Get
++@ stub ADL_Workstation_LoadBalancing_Set
++@ stub ADL_Workstation_RAS_Get_Error_Counts
++@ stub ADL_Workstation_RAS_Get_Features
++@ stub ADL_Workstation_RAS_Reset_Error_Counts
++@ stub ADL_Workstation_RAS_Set_Features
++@ stub ADL_Workstation_SDISegmentList_Get
++@ stub ADL_Workstation_SDI_Caps
++@ stub ADL_Workstation_SDI_Get
++@ stub ADL_Workstation_SDI_Set
++@ stub ADL_Workstation_Stereo_Get
++@ stub ADL_Workstation_Stereo_Set
++@ stub ADL_Workstation_UnsupportedDisplayModes_Enable
++@ stub AmdPowerXpressRequestHighPerformance
++@ stub Desktop_Detach
++@ stub Send
++@ stub SendX2
+diff --git a/dlls/atiadlxx/atiadlxx_main.c b/dlls/atiadlxx/atiadlxx_main.c
+new file mode 100644
+index 00000000000..3518761b7f6
+--- /dev/null
++++ b/dlls/atiadlxx/atiadlxx_main.c
+@@ -0,0 +1,91 @@
++#include <stdarg.h>
++
++#include "windef.h"
++#include "winbase.h"
++#include "wine/debug.h"
++
++WINE_DEFAULT_DEBUG_CHANNEL(atiadlxx);
++
++BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, void *reserved)
++{
++    TRACE("(%p, %u, %p)\n", instance, reason, reserved);
++
++    switch (reason)
++    {
++    case DLL_PROCESS_ATTACH:
++        DisableThreadLibraryCalls(instance);
++        break;
++    }
++
++    return TRUE;
++}
++
++typedef void *(CALLBACK *ADL_MAIN_MALLOC_CALLBACK)(int);
++typedef void *ADL_CONTEXT_HANDLE;
++
++typedef struct ADLVersionsInfo
++{
++    char strDriverVer[256];
++    char strCatalystVersion[256];
++    char strCatalystWebLink[256];
++} ADLVersionsInfo, *LPADLVersionsInfo;
++
++typedef struct ADLVersionsInfoX2
++{
++    char strDriverVer[256];
++    char strCatalystVersion[256];
++    char strCrimsonVersion[256];
++    char strCatalystWebLink[256];
++} ADLVersionsInfoX2, *LPADLVersionsInfoX2;
++
++static const ADLVersionsInfo version = {
++    "16.11.2",
++    "16.11.2",
++    "",
++};
++
++static const ADLVersionsInfoX2 version2 = {
++    "16.11.2",
++    "16.11.2",
++    "16.11.2",
++    "",
++};
++
++int WINAPI ADL2_Main_Control_Create(ADL_MAIN_MALLOC_CALLBACK cb, int arg, ADL_CONTEXT_HANDLE *ptr)
++{
++    FIXME("cb %p, arg %d, ptr %p stub!\n", cb, arg, ptr);
++    return 0;
++}
++
++int WINAPI ADL_Main_Control_Create(ADL_MAIN_MALLOC_CALLBACK cb, int arg)
++{
++    FIXME("cb %p, arg %d stub!\n", cb, arg);
++    return 0;
++}
++
++int WINAPI ADL_Main_Control_Destroy(void)
++{
++    FIXME("stub!\n");
++    return 0;
++}
++
++int WINAPI ADL2_Adapter_NumberOfAdapters_Get(ADL_CONTEXT_HANDLE *ptr, int *count)
++{
++    FIXME("ptr %p, count %p stub!\n", ptr, count);
++    *count = 0;
++    return 0;
++}
++
++int WINAPI ADL2_Graphics_VersionsX2_Get(ADL_CONTEXT_HANDLE *ptr, ADLVersionsInfoX2 *ver)
++{
++    FIXME("ptr %p, ver %p stub!\n", ptr, ver);
++    memcpy(ver, &version2, sizeof(version2));
++    return 0;
++}
++
++int WINAPI ADL_Graphics_Versions_Get(ADLVersionsInfo *ver)
++{
++    FIXME("ver %p stub!\n", ver);
++    memcpy(ver, &version, sizeof(version));
++    return 0;
++}
+From cbfd1dad246e246ad4ed9d6af45b46a3376f21cf Mon Sep 17 00:00:00 2001
+From: Arkadiusz Hiler <ahiler@codeweavers.com>
+Date: Mon, 12 Oct 2020 17:46:27 +0300
+Subject: [PATCH] atidlxx: Stub GPU/display enumeration and clock/memory info.
+
+Shadow of War uses atiadlxx to query the following GPU information:
+
+ * current memory frequency
+ * current core frequency
+ * memory size
+ * memory bandwidth
+
+Those are used to apprise the GPU and recommend user settings.
+
+Most of them can be fetched via AMD's powerplay sysfs entries / wined3d
+helpers. The only value that is not exposed is the memory bandwith so we
+set it to the value my RX580 reports on Windows.
+
+Because of that on high end system the game may recommend lower settings
+than it would with the real value, and the other way around on low end
+systems.
+
+We also report some "sane default" in case we can't find the powerplay
+entries - this may be the case with nvapi hack enabled when we report
+any NVIDIA card as RX480.
+
+ADL2 stubs used by Call of Duty games are untouched and still report 0
+GPUs.
+---
+ dlls/atiadlxx/Makefile.in     |   2 +
+ dlls/atiadlxx/atiadlxx.spec   |  18 +-
+ dlls/atiadlxx/atiadlxx_main.c | 367 ++++++++++++++++++++++++++++++++--
+ 3 files changed, 365 insertions(+), 22 deletions(-)
+
+diff --git a/dlls/atiadlxx/Makefile.in b/dlls/atiadlxx/Makefile.in
+index 78af7168c20..7708c714213 100644
+--- a/dlls/atiadlxx/Makefile.in
++++ b/dlls/atiadlxx/Makefile.in
+@@ -1,4 +1,6 @@
+ MODULE = atiadlxx.dll
++IMPORTS = wined3d
++
+ EXTRADLLFLAGS = -mno-cygwin -Wb,--prefer-native
+ 
+ C_SRCS = \
+diff --git a/dlls/atiadlxx/atiadlxx.spec b/dlls/atiadlxx/atiadlxx.spec
+index e2a1f46a838..e2fb060ae8d 100644
+--- a/dlls/atiadlxx/atiadlxx.spec
++++ b/dlls/atiadlxx/atiadlxx.spec
+@@ -681,14 +681,14 @@
+ @ stub ADL_APO_AudioDelay_Set
+ @ stub ADL_AdapterLimitation_Caps
+ @ stub ADL_AdapterX2_Caps
+-@ stub ADL_Adapter_ASICFamilyType_Get
++@ stdcall ADL_Adapter_ASICFamilyType_Get(long ptr ptr)
+ @ stub ADL_Adapter_ASICInfo_Get
+ @ stub ADL_Adapter_Accessibility_Get
+ @ stub ADL_Adapter_Active_Get
+ @ stub ADL_Adapter_Active_Set
+ @ stub ADL_Adapter_Active_SetPrefer
+ @ stub ADL_Adapter_AdapterInfoX2_Get
+-@ stub ADL_Adapter_AdapterInfo_Get
++@ stdcall ADL_Adapter_AdapterInfo_Get(ptr long)
+ @ stub ADL_Adapter_AdapterList_Disable
+ @ stub ADL_Adapter_Aspects_Get
+ @ stub ADL_Adapter_AudioChannelSplitConfiguration_Get
+@@ -714,8 +714,8 @@
+ @ stub ADL_Adapter_CrossdisplayInfo_Get
+ @ stub ADL_Adapter_CrossdisplayInfo_Set
+ @ stub ADL_Adapter_CrossfireX2_Get
+-@ stub ADL_Adapter_Crossfire_Caps
+-@ stub ADL_Adapter_Crossfire_Get
++@ stdcall ADL_Adapter_Crossfire_Caps(long ptr ptr ptr)
++@ stdcall ADL_Adapter_Crossfire_Get(long ptr ptr)
+ @ stub ADL_Adapter_Crossfire_Set
+ @ stub ADL_Adapter_DefaultAudioChannelTable_Load
+ @ stub ADL_Adapter_DisplayAudioEndpoint_Enable
+@@ -736,14 +736,14 @@
+ @ stub ADL_Adapter_LocalDisplayState_Get
+ @ stub ADL_Adapter_MaxCursorSize_Get
+ @ stub ADL_Adapter_MemoryInfo2_Get
+-@ stub ADL_Adapter_MemoryInfo_Get
++@ stdcall ADL_Adapter_MemoryInfo_Get(long ptr)
+ @ stub ADL_Adapter_MirabilisSupport_Get
+ @ stub ADL_Adapter_ModeSwitch
+ @ stub ADL_Adapter_ModeTimingOverride_Caps
+ @ stub ADL_Adapter_Modes_ReEnumerate
+ @ stub ADL_Adapter_NumberOfActivatableSources_Get
+-@ stub ADL_Adapter_NumberOfAdapters_Get
+-@ stub ADL_Adapter_ObservedClockInfo_Get
++@ stdcall ADL_Adapter_NumberOfAdapters_Get(ptr)
++@ stdcall ADL_Adapter_ObservedClockInfo_Get(long ptr ptr)
+ @ stub ADL_Adapter_ObservedGameClockInfo_Get
+ @ stub ADL_Adapter_Primary_Get
+ @ stub ADL_Adapter_Primary_Set
+@@ -844,7 +844,7 @@
+ @ stub ADL_Display_DisplayContent_Cap
+ @ stub ADL_Display_DisplayContent_Get
+ @ stub ADL_Display_DisplayContent_Set
+-@ stub ADL_Display_DisplayInfo_Get
++@ stdcall ADL_Display_DisplayInfo_Get(long long ptr long)
+ @ stub ADL_Display_DisplayMapConfig_Get
+ @ stub ADL_Display_DisplayMapConfig_PossibleAddAndRemove
+ @ stub ADL_Display_DisplayMapConfig_Set
+@@ -969,7 +969,7 @@
+ @ stub ADL_Display_WriteAndReadI2CLargePayload
+ @ stub ADL_Display_WriteAndReadI2CRev_Get
+ @ stub ADL_Flush_Driver_Data
+-@ stub ADL_Graphics_Platform_Get
++@ stdcall ADL_Graphics_Platform_Get(ptr)
+ @ stdcall ADL_Graphics_Versions_Get(ptr)
+ @ stub ADL_MMD_FeatureList_Get
+ @ stub ADL_MMD_FeatureValuesX2_Get
+diff --git a/dlls/atiadlxx/atiadlxx_main.c b/dlls/atiadlxx/atiadlxx_main.c
+index 3518761b7f6..66a64379ffe 100644
+--- a/dlls/atiadlxx/atiadlxx_main.c
++++ b/dlls/atiadlxx/atiadlxx_main.c
+@@ -1,8 +1,43 @@
++/* Headers: https://github.com/GPUOpen-LibrariesAndSDKs/display-library */
++
+ #include <stdarg.h>
++#include <stdio.h>
++#include <stdlib.h>
+ 
++#define COBJMACROS
+ #include "windef.h"
+ #include "winbase.h"
++#include "winuser.h"
++#include "objbase.h"
+ #include "wine/debug.h"
++#include "wine/wined3d.h"
++
++#define MAX_GPUS 64
++#define VENDOR_AMD 0x1002
++
++#define ADL_OK                            0
++#define ADL_ERR                          -1
++#define ADL_ERR_INVALID_PARAM            -3
++#define ADL_ERR_INVALID_ADL_IDX          -5
++#define ADL_ERR_NOT_SUPPORTED            -8
++#define ADL_ERR_NULL_POINTER             -9
++
++#define ADL_DISPLAY_DISPLAYINFO_DISPLAYCONNECTED            0x00000001
++#define ADL_DISPLAY_DISPLAYINFO_DISPLAYMAPPED               0x00000002
++#define ADL_DISPLAY_DISPLAYINFO_MASK 0x31fff
++
++#define ADL_ASIC_DISCRETE    (1 << 0)
++#define ADL_ASIC_MASK        0xAF
++
++enum ADLPlatForm
++{
++    GRAPHICS_PLATFORM_DESKTOP  = 0,
++    GRAPHICS_PLATFORM_MOBILE   = 1
++};
++#define GRAPHICS_PLATFORM_UNKNOWN -1
++
++
++static struct wined3d *wined3d;
+ 
+ WINE_DEFAULT_DEBUG_CHANNEL(atiadlxx);
+ 
+@@ -25,21 +60,83 @@ BOOL WINAPI DllMain(HINSTANCE instance, DWORD reason, void *reserved)
+ typedef void *(CALLBACK *ADL_MAIN_MALLOC_CALLBACK)(int);
+ typedef void *ADL_CONTEXT_HANDLE;
+ 
++ADL_MAIN_MALLOC_CALLBACK adl_malloc;
++#define ADL_MAX_PATH 256
++
+ typedef struct ADLVersionsInfo
+ {
+-    char strDriverVer[256];
+-    char strCatalystVersion[256];
+-    char strCatalystWebLink[256];
++    char strDriverVer[ADL_MAX_PATH];
++    char strCatalystVersion[ADL_MAX_PATH];
++    char strCatalystWebLink[ADL_MAX_PATH];
+ } ADLVersionsInfo, *LPADLVersionsInfo;
+ 
+ typedef struct ADLVersionsInfoX2
+ {
+-    char strDriverVer[256];
+-    char strCatalystVersion[256];
+-    char strCrimsonVersion[256];
+-    char strCatalystWebLink[256];
++    char strDriverVer[ADL_MAX_PATH];
++    char strCatalystVersion[ADL_MAX_PATH];
++    char strCrimsonVersion[ADL_MAX_PATH];
++    char strCatalystWebLink[ADL_MAX_PATH];
+ } ADLVersionsInfoX2, *LPADLVersionsInfoX2;
+ 
++typedef struct ADLAdapterInfo {
++    int iSize;
++    int iAdapterIndex;
++    char strUDID[ADL_MAX_PATH];
++    int iBusNumber;
++    int iDeviceNumber;
++    int iFunctionNumber;
++    int iVendorID;
++    char strAdapterName[ADL_MAX_PATH];
++    char strDisplayName[ADL_MAX_PATH];
++    int iPresent;
++    int iExist;
++    char strDriverPath[ADL_MAX_PATH];
++    char strDriverPathExt[ADL_MAX_PATH];
++    char strPNPString[ADL_MAX_PATH];
++    int iOSDisplayIndex;
++} ADLAdapterInfo, *LPADLAdapterInfo;
++
++typedef struct ADLDisplayID
++{
++    int iDisplayLogicalIndex;
++    int iDisplayPhysicalIndex;
++    int iDisplayLogicalAdapterIndex;
++    int iDisplayPhysicalAdapterIndex;
++} ADLDisplayID, *LPADLDisplayID;
++
++typedef struct ADLDisplayInfo
++{
++    ADLDisplayID displayID;
++    int  iDisplayControllerIndex;
++    char strDisplayName[ADL_MAX_PATH];
++    char strDisplayManufacturerName[ADL_MAX_PATH];
++    int  iDisplayType;
++    int  iDisplayOutputType;
++    int  iDisplayConnector;
++    int  iDisplayInfoMask;
++    int  iDisplayInfoValue;
++} ADLDisplayInfo, *LPADLDisplayInfo;
++
++typedef struct ADLCrossfireComb
++{
++    int iNumLinkAdapter;
++    int iAdaptLink[3];
++} ADLCrossfireComb;
++
++typedef struct ADLCrossfireInfo
++{
++  int iErrorCode;
++  int iState;
++  int iSupported;
++} ADLCrossfireInfo;
++
++typedef struct ADLMemoryInfo
++{
++    long long iMemorySize;
++    char strMemoryType[ADL_MAX_PATH];
++    long long iMemoryBandwidth;
++} ADLMemoryInfo, *LPADLMemoryInfo;
++
+ static const ADLVersionsInfo version = {
+     "16.11.2",
+     "16.11.2",
+@@ -56,38 +153,282 @@ static const ADLVersionsInfoX2 version2 = {
+ int WINAPI ADL2_Main_Control_Create(ADL_MAIN_MALLOC_CALLBACK cb, int arg, ADL_CONTEXT_HANDLE *ptr)
+ {
+     FIXME("cb %p, arg %d, ptr %p stub!\n", cb, arg, ptr);
+-    return 0;
++    return ADL_OK;
+ }
+ 
+ int WINAPI ADL_Main_Control_Create(ADL_MAIN_MALLOC_CALLBACK cb, int arg)
+ {
+     FIXME("cb %p, arg %d stub!\n", cb, arg);
+-    return 0;
++    adl_malloc = cb;
++
++    if ((wined3d = wined3d_create(0)))
++        return ADL_OK;
++    else
++        return ADL_ERR;
+ }
+ 
+ int WINAPI ADL_Main_Control_Destroy(void)
+ {
+     FIXME("stub!\n");
+-    return 0;
++
++    if (wined3d != NULL)
++        wined3d_decref(wined3d);
++
++    return ADL_OK;
+ }
+ 
+ int WINAPI ADL2_Adapter_NumberOfAdapters_Get(ADL_CONTEXT_HANDLE *ptr, int *count)
+ {
+     FIXME("ptr %p, count %p stub!\n", ptr, count);
++
+     *count = 0;
+-    return 0;
++
++    return ADL_OK;
+ }
+ 
+ int WINAPI ADL2_Graphics_VersionsX2_Get(ADL_CONTEXT_HANDLE *ptr, ADLVersionsInfoX2 *ver)
+ {
+     FIXME("ptr %p, ver %p stub!\n", ptr, ver);
+     memcpy(ver, &version2, sizeof(version2));
+-    return 0;
++    return ADL_OK;
+ }
+ 
+ int WINAPI ADL_Graphics_Versions_Get(ADLVersionsInfo *ver)
+ {
+     FIXME("ver %p stub!\n", ver);
+     memcpy(ver, &version, sizeof(version));
+-    return 0;
++    return ADL_OK;
++}
++
++int WINAPI ADL_Adapter_NumberOfAdapters_Get(int *count)
++{
++    FIXME("count %p stub!\n", count);
++    *count = wined3d_get_adapter_count(wined3d);
++    TRACE("*count = %d\n", *count);
++    return ADL_OK;
++}
++
++static BOOL get_adapter_identifier(int index, struct wined3d_adapter_identifier *identifier)
++{
++    struct wined3d_adapter *adapter;
++    HRESULT hr;
++
++    adapter = wined3d_get_adapter(wined3d, index);
++    if (adapter == NULL)
++        return FALSE;
++
++    memset(identifier, 0, sizeof(*identifier));
++    hr = wined3d_adapter_get_identifier(adapter, 0, identifier);
++
++    if (!SUCCEEDED(hr))
++        return FALSE;
++
++    return TRUE;
++}
++
++/* yep, seriously */
++static int convert_vendor_id(int id)
++{
++    char str[16];
++    snprintf(str, ARRAY_SIZE(str), "%x", id);
++    return atoi(str);
++}
++
++int WINAPI ADL_Adapter_AdapterInfo_Get(ADLAdapterInfo *adapters, int input_size)
++{
++    int count, i;
++    struct wined3d_adapter_identifier identifier;
++
++    FIXME("adapters %p, input_size %d, stub!\n", adapters, input_size);
++
++    count = wined3d_get_adapter_count(wined3d);
++
++    if (!adapters) return ADL_ERR_INVALID_PARAM;
++    if (input_size != count * sizeof(ADLAdapterInfo)) return ADL_ERR_INVALID_PARAM;
++
++    memset(adapters, 0, input_size);
++
++    for (i = 0; i < count; i++)
++    {
++        adapters[i].iSize = sizeof(ADLAdapterInfo);
++        adapters[i].iAdapterIndex = i;
++
++        if (!get_adapter_identifier(i, &identifier))
++            return ADL_ERR;
++
++        adapters[i].iVendorID = convert_vendor_id(identifier.vendor_id);
++    }
++
++    return ADL_OK;
++}
++
++int WINAPI ADL_Display_DisplayInfo_Get(int adapter_index, int *num_displays, ADLDisplayInfo **info, int force_detect)
++{
++    struct wined3d_adapter *adapter;
++    struct wined3d_output *output;
++    int i;
++
++    FIXME("adapter %d, num_displays %p, info %p stub!\n", adapter_index, num_displays, info);
++
++    if (info == NULL || num_displays == NULL) return ADL_ERR_NULL_POINTER;
++
++    adapter = wined3d_get_adapter(wined3d, adapter_index);
++    if (adapter == NULL) return ADL_ERR_INVALID_PARAM;
++
++    *num_displays = wined3d_adapter_get_output_count(adapter);
++
++    if (*num_displays == 0)
++        return ADL_OK;
++
++    *info = adl_malloc(*num_displays * sizeof(**info));
++    memset(*info, 0, *num_displays * sizeof(**info));
++
++    for (i = 0; i < *num_displays; i++)
++    {
++        output = wined3d_adapter_get_output(adapter, i);
++        if (output == NULL)
++            return ADL_ERR;
++
++        (*info)[i].displayID.iDisplayLogicalIndex = i;
++        (*info)[i].iDisplayInfoValue = ADL_DISPLAY_DISPLAYINFO_DISPLAYCONNECTED | ADL_DISPLAY_DISPLAYINFO_DISPLAYMAPPED;
++        (*info)[i].iDisplayInfoMask = (*info)[i].iDisplayInfoValue;
++    }
++
++    return ADL_OK;
++}
++
++int WINAPI ADL_Adapter_Crossfire_Caps(int adapter_index, int *preffered, int *num_comb, ADLCrossfireComb** comb)
++{
++    FIXME("adapter %d, preffered %p, num_comb %p, comb %p stub!\n", adapter_index, preffered, num_comb, comb);
++    return ADL_ERR;
++}
++
++int WINAPI ADL_Adapter_Crossfire_Get(int adapter_index, ADLCrossfireComb *comb, ADLCrossfireInfo *info)
++{
++    FIXME("adapter %d, comb %p, info %p, stub!\n", adapter_index, comb, info);
++    return ADL_ERR;
++}
++
++int WINAPI ADL_Adapter_ASICFamilyType_Get(int adapter_index, int *asic_type, int *valids)
++{
++    struct wined3d_adapter_identifier identifier;
++
++    FIXME("adapter %d, asic_type %p, valids %p, stub!\n", adapter_index, asic_type, valids);
++
++    if (asic_type == NULL || valids == NULL)
++        return  ADL_ERR_NULL_POINTER;
++
++    if (!get_adapter_identifier(adapter_index, &identifier))
++        return ADL_ERR_INVALID_ADL_IDX;
++
++    if (identifier.vendor_id != VENDOR_AMD)
++        return ADL_ERR_NOT_SUPPORTED;
++
++    *asic_type = ADL_ASIC_DISCRETE;
++    *valids = ADL_ASIC_MASK;
++
++    return ADL_OK;
++}
++
++static int get_max_clock(const char *clock, int default_value)
++{
++    char path[MAX_PATH], line[256];
++    FILE *file;
++    int drm_card, value = 0;
++
++    for (drm_card = 0; drm_card < MAX_GPUS; drm_card++)
++    {
++        sprintf(path, "/sys/class/drm/card%d/device/pp_dpm_%s", drm_card, clock);
++        file = fopen(path, "r");
++
++        if (file == NULL)
++            continue;
++
++        while (fgets(line, sizeof(line), file) != NULL)
++        {
++            char *number;
++
++            number = strchr(line, ' ');
++            if (number == NULL)
++            {
++                WARN("pp_dpm_%s file has unexpected format\n", clock);
++                break;
++            }
++
++            number++;
++            value = max(strtol(number, NULL, 0), value);
++        }
++    }
++
++    if (value != 0)
++        return value;
++
++    return default_value;
++}
++
++/* documented in the "Linux Specific APIs" section, present and used on Windows */
++/* the name and documentation suggests that this returns current freqs, but it's actually max */
++int WINAPI ADL_Adapter_ObservedClockInfo_Get(int adapter_index, int *core_clock, int *memory_clock)
++{
++    struct wined3d_adapter_identifier identifier;
++
++    FIXME("adapter %d, core_clock %p, memory_clock %p, stub!\n", adapter_index, core_clock, memory_clock);
++
++    if (core_clock == NULL || memory_clock == NULL) return ADL_ERR;
++    if (!get_adapter_identifier(adapter_index, &identifier)) return ADL_ERR;
++    if (identifier.vendor_id != VENDOR_AMD) return ADL_ERR_INVALID_ADL_IDX;
++
++    /* default values based on RX580 */
++    *core_clock = get_max_clock("sclk", 1350);
++    *memory_clock = get_max_clock("mclk", 2000);
++
++    TRACE("*core_clock: %i, *memory_clock %i\n", *core_clock, *memory_clock);
++
++    return ADL_OK;
++}
++
++/* documented in the "Linux Specific APIs" section, present and used on Windows */
++int WINAPI ADL_Adapter_MemoryInfo_Get(int adapter_index, ADLMemoryInfo *mem_info)
++{
++    struct wined3d_adapter_identifier identifier;
++
++    FIXME("adapter %d, mem_info %p stub!\n", adapter_index, mem_info);
++
++    if (mem_info == NULL) return ADL_ERR_NULL_POINTER;
++    if (!get_adapter_identifier(adapter_index, &identifier)) return ADL_ERR_INVALID_ADL_IDX;
++    if (identifier.vendor_id != VENDOR_AMD) return ADL_ERR;
++
++    mem_info->iMemorySize = identifier.video_memory;
++    mem_info->iMemoryBandwidth = 256000; /* not exposed on Linux, probably needs a lookup table */
++
++    TRACE("iMemoryBandwidth %lli, iMemorySize %lli\n", mem_info->iMemoryBandwidth, mem_info->iMemorySize);
++    return ADL_OK;
++}
++
++int WINAPI ADL_Graphics_Platform_Get(int *platform)
++{
++    struct wined3d_adapter_identifier identifier;
++    int count, i;
++
++    FIXME("platform %p, stub!\n", platform);
++
++    *platform = GRAPHICS_PLATFORM_UNKNOWN;
++
++    count = wined3d_get_adapter_count(wined3d);
++
++    for (i = 0; i < count; i ++)
++    {
++        if (!get_adapter_identifier(i, &identifier))
++            continue;
++
++        if (identifier.vendor_id == VENDOR_AMD)
++            *platform = GRAPHICS_PLATFORM_DESKTOP;
++    }
++
++    /* NOTE: The real value can be obtained by doing:
++     * 1. ioctl(DRM_AMDGPU_INFO) with AMDGPU_INFO_DEV_INFO - dev_info.ids_flags & AMDGPU_IDS_FLAGS_FUSION
++     * 2. VkPhysicalDeviceType() if we ever switch to wined3d vk adapter implementation
++     */
++
++    return ADL_OK;
+ }

--- a/wine-tkg-git/legoisland_168726.mypatch
+++ b/wine-tkg-git/legoisland_168726.mypatch
@@ -74,8 +74,8 @@ index 11861f2a12..3e7a2df0c4 100644
 
  /* The execute function */
  HRESULT d3d_execute_buffer_execute(struct d3d_execute_buffer *execute_buffer,
--        struct d3d_device *device) DECLSPEC_HIDDEN;
-+        struct d3d_device *device, D3DRECT* pick_rect) DECLSPEC_HIDDEN;
+-        struct d3d_device *device);
++        struct d3d_device *device, D3DRECT* pick_rect);
 
  /*****************************************************************************
   * IDirect3DVertexBuffer
@@ -236,10 +236,10 @@ index 80dbdfd88b..38b9c8c62c 100644
 +        D3DVALUE bias = 0.0f;
 +
 +        /* Edge function - determines whether pixel is inside triangle */
-+        D3DVALUE w = (v2->u1.sx-v1->u1.sx)*(y-v1->u2.sy) - (v2->u2.sy-v1->u2.sy)*(x-v1->u1.sx);
++        D3DVALUE w = (v2->sx-v1->sx)*(y-v1->sy) - (v2->sy-v1->sy)*(x-v1->sx);
 +
 +        /* Force top-left rule */
-+        if ((v1->u2.sy == v2->u2.sy && v1->u1.sx > v2->u1.sx) || (v1->u2.sy < v2->u2.sy))
++        if ((v1->sy == v2->sy && v1->sx > v2->sx) || (v1->sy < v2->sy))
 +            bias = 1.0f;
 +
 +        if (w < bias)
@@ -279,8 +279,8 @@ index 80dbdfd88b..38b9c8c62c 100644
 +        D3DTLVERTEX* v2 = &verts[(i+1)%TRIANGLE_SIZE];
 +        D3DTLVERTEX* v3 = &verts[(i+2)%TRIANGLE_SIZE];
 +
-+        z1 += v3->u3.sz * (x - v1->u1.sx) * (y - v2->u2.sy) - v2->u3.sz * (x - v1->u1.sx) * (y - v3->u2.sy);
-+        z2 += (x - v1->u1.sx) * (y - v2->u2.sy) - (x - v1->u1.sx) * (y - v3->u2.sy);
++        z1 += v3->sz * (x - v1->sx) * (y - v2->sy) - v2->sz * (x - v1->sx) * (y - v3->sy);
++        z2 += (x - v1->sx) * (y - v2->sy) - (x - v1->sx) * (y - v3->sy);
 +    }
 +
 +    return z1 / z2;
@@ -348,7 +348,7 @@ index 80dbdfd88b..38b9c8c62c 100644
 @@ -174,6 +290,67 @@ HRESULT d3d_execute_buffer_execute(struct d3d_execute_buffer *buffer, struct d3d
                      {
                          case 3:
-                             indices[(i * primitive_size) + 2] = ci->u3.v3;
+                             indices[(i * primitive_size) + 2] = ci->v3;
 +
 +                            if (pick_rect != NULL) {
 +                                INT j;
@@ -358,9 +358,9 @@ index 80dbdfd88b..38b9c8c62c 100644
 +
 +                                    /* Get index of vertex from D3DTRIANGLE struct */
 +                                    switch (j) {
-+                                    case 0: box.left = vertex_size * ci->u1.v1; break;
-+                                    case 1: box.left = vertex_size * ci->u2.v2; break;
-+                                    case 2: box.left = vertex_size * ci->u3.v3; break;
++                                    case 0: box.left = vertex_size * ci->v1; break;
++                                    case 1: box.left = vertex_size * ci->v2; break;
++                                    case 2: box.left = vertex_size * ci->v3; break;
 +                                    }
 +
 +                                    box.right = box.left + vertex_size;
@@ -376,7 +376,7 @@ index 80dbdfd88b..38b9c8c62c 100644
 +                                }
 +
 +                                /* Use vertices acquired above to test for clicking */
-+                                if (d3d_execute_buffer_pick_test(pick_rect->u1.x1, pick_rect->u2.y1, verts))
++                                if (d3d_execute_buffer_pick_test(pick_rect->x1, pick_rect->y1, verts))
 +                                {
 +                                    D3DPICKRECORD* record;
 +
@@ -398,7 +398,7 @@ index 80dbdfd88b..38b9c8c62c 100644
 +                                    record->dwOffset = (DWORD)instr - (DWORD)buffer->desc.lpData - is;
 +
 +                                    /* Formula for returning the Z value at this X/Y */
-+                                    record->dvZ = d3d_execute_buffer_z_value_at_coords(pick_rect->u1.x1, pick_rect->u2.y1, verts);
++                                    record->dvZ = d3d_execute_buffer_z_value_at_coords(pick_rect->x1, pick_rect->y1, verts);
 +
 +                                    /* Point device info to new record information */
 +                                    device->pick_records = new_record_array;
@@ -412,7 +412,7 @@ index 80dbdfd88b..38b9c8c62c 100644
 +
                              /* Drop through. */
                          case 2:
-                             indices[(i * primitive_size) + 1] = ci->u2.v2;
+                             indices[(i * primitive_size) + 1] = ci->v2;
 @@ -184,14 +361,18 @@ HRESULT d3d_execute_buffer_execute(struct d3d_execute_buffer *buffer, struct d3d
 
                  wined3d_resource_unmap(wined3d_buffer_get_resource(buffer->index_buffer), 0);

--- a/wine-tkg-git/mfplat_nv12_d3d11_buffers.mypatch
+++ b/wine-tkg-git/mfplat_nv12_d3d11_buffers.mypatch
@@ -61,6 +61,6 @@ index e04cc1a9251..27c76ef988e 100644
          copy_image(buffer, buffer->dxgi_surface.map_desc.pData, buffer->dxgi_surface.map_desc.RowPitch,
 -                buffer->_2d.linear_buffer, buffer->_2d.width, buffer->_2d.width, buffer->_2d.height);
 +                buffer->_2d.linear_buffer, buffer->_2d.width, buffer->_2d.width, lines);
-         dxgi_surface_buffer_unmap(buffer);
+         dxgi_surface_buffer_unmap(buffer, MF2DBuffer_LockFlags_ReadWrite);
  
          free(buffer->_2d.linear_buffer);


### PR DESCRIPTION
Add VisualStudio2019_patches for some patches needed to work with VS2019 and the Refcount patch for IDA Pro with IDaPython3 support

Also rebase the legoisland ddraw pick patch to use Nameless stucts and union