### PR TITLE
[wine-tkg] Add patch to disable using SDL by default

### DIFF
--- a/wine-tkg-git/README.md
+++ b/wine-tkg-git/README.md
@@ -71,3 +71,4 @@
 - 0001-Force-full-erase-when-WM_PAINT-in-LVS_EX_DOUBLEBUFFE.mypatch : Force a background erase on LVS_EX_DOUBLEBUFFERED listviews. Fix black background for listviews on some apps.
 - VisualStudio2019_patches.mypatch : A series of patches for a working installation of Visual Studio 2019
 - Proper_refcount_forwarded_exports.mypatch : Allow forwarded exports to properly tracks their refcounts, avoiding spuruious DLL unloading. Needed for IDA Pro IDAPython3 
+- disable_sdl.mypatch: Disable SDL by default (controlled by DWORD `Enable SDL` at  `HKLM\\System\\CurrentControlSet\\Service\\winebus`). It resolves reinit some device on wineserver start, but may disable some gamepads for wine (to fix change this option in regedit)

--- a/wine-tkg-git/disable_sdl.mypatch
+++ b/wine-tkg-git/disable_sdl.mypatch
@@ -1,0 +1,13 @@
+diff --git a/dlls/winebus.sys/main.c b/dlls/winebus.sys/main.c
+index ae676f80565..34d72dcf27c 100644
+--- a/dlls/winebus.sys/main.c
++++ b/dlls/winebus.sys/main.c
+@@ -781,7 +781,7 @@ static NTSTATUS fdo_pnp_dispatch(DEVICE_OBJECT *device, IRP *irp)
+         mouse_device_create();
+         keyboard_device_create();
+ 
+-        if (!check_bus_option(L"Enable SDL", 1) || sdl_driver_init())
++        if (!check_bus_option(L"Enable SDL", 0) || sdl_driver_init())
+         {
+             udev_driver_init();
+             iohid_driver_init();


### PR DESCRIPTION
When wine uses SDL it may trigger reinit for some devices - it leads to this devices may stop working in runned programs. E.g. SDL trigger reinit for keyboard Logitech g815, and it stops LED controls in OpenRGB.

This PR disable usage of SDL by default. To enable SDL may be used regedit option `Enable SDL` with type DWORD at `HKLM\\System\\CurrentControlSet\\Service\\winebus`:
 - 0: Disable SDL (now default state)
 - 1: Enable SDL