### PR TITLE
linux: fix bbr3 patch for 6.19.6 AccECN additions

### DIFF
--- a/linux619-tkg/bbr3.mypatch
+++ b/linux619-tkg/bbr3.mypatch
@@ -129,16 +129,19 @@ index 0deb5e9dd911..4e01320786b3 100644
  };
  
  /* Information about inbound ACK, passed to cong_ops->in_ack_event() */
-@@ -1203,7 +1225,11 @@ enum tcp_ca_ack_event_flags {
- #define TCP_CONG_NON_RESTRICTED		BIT(0)
- /* Requires ECN/ECT set on all packets */
- #define TCP_CONG_NEEDS_ECN		BIT(1)
--#define TCP_CONG_MASK	(TCP_CONG_NON_RESTRICTED | TCP_CONG_NEEDS_ECN)
+@@ -1233,7 +1233,10 @@ enum tcp_ca_ack_event_flags {
+ #define TCP_CONG_ECT_1_NEGOTIATION	BIT(3)
+ /* Cannot fallback to RFC3168 during AccECN negotiation */
+ #define TCP_CONG_NO_FALLBACK_RFC3168	BIT(4)
+-#define TCP_CONG_MASK  (TCP_CONG_NON_RESTRICTED | TCP_CONG_NEEDS_ECN | \
+-			TCP_CONG_NEEDS_ACCECN | TCP_CONG_ECT_1_NEGOTIATION | \
+-			TCP_CONG_NO_FALLBACK_RFC3168)
 +/* Wants notification of CE events (CA_EVENT_ECN_IS_CE, CA_EVENT_ECN_NO_CE). */
-+#define TCP_CONG_WANTS_CE_EVENTS	BIT(2)
-+#define TCP_CONG_MASK	(TCP_CONG_NON_RESTRICTED | \
-+			 TCP_CONG_NEEDS_ECN | \
-+			 TCP_CONG_WANTS_CE_EVENTS)
++#define TCP_CONG_WANTS_CE_EVENTS	BIT(5)
++#define TCP_CONG_MASK  (TCP_CONG_NON_RESTRICTED | TCP_CONG_NEEDS_ECN | \
++			TCP_CONG_WANTS_CE_EVENTS | TCP_CONG_NEEDS_ACCECN | \
++			TCP_CONG_ECT_1_NEGOTIATION | \
++			TCP_CONG_NO_FALLBACK_RFC3168)
  
  union tcp_cc_info;
  


### PR DESCRIPTION
Update the BBR3 hunk in `linux619-tkg` to account for AccECN-related definitions added in 6.19.6. `BIT(2)` through `BIT(4)` are now taken by `TCP_CONG_NEEDS_ACCECN`, `TCP_CONG_ECT_1_NEGOTIATION`, and `TCP_CONG_NO_FALLBACK_RFC3168` respectively, so `TCP_CONG_WANTS_CE_EVENTS` is reassigned to `BIT(5)` and the context lines are updated to match.